### PR TITLE
feat(selenium): add configurable outer column keys (OC_*)

### DIFF
--- a/selenium/internals.h
+++ b/selenium/internals.h
@@ -167,3 +167,27 @@
 #    endif
 
 #endif
+
+// ╭─────────────────────────────────────────────────────────╮
+// │       Outer column keys (42-key boards only)            │
+// ╰─────────────────────────────────────────────────────────╯
+// Defaults match the Selenium specification. Override in options.h.
+
+#ifndef OC_TL
+#    define OC_TL KC_TAB
+#endif
+#ifndef OC_TR
+#    define OC_TR KC_BSPC
+#endif
+#ifndef OC_ML
+#    define OC_ML KC_ESC
+#endif
+#ifndef OC_MR
+#    define OC_MR KC_ENT
+#endif
+#ifndef OC_BL
+#    define OC_BL KC_LSFT
+#endif
+#ifndef OC_BR
+#    define OC_BR KC_RSFT
+#endif

--- a/selenium/keymap.c
+++ b/selenium/keymap.c
@@ -49,11 +49,11 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
     // 0. Base layer
     [_base] = SELENIUM_LAYOUT(
-        KC_TAB,   KC_Q,   KC_W,   KC_E,   KC_R,   KC_T,        KC_Y,  KC_U,   KC_I,     KC_O,    KC_P,     KC_BSPC,
-        KC_ESC,   KC_AA,  KC_SS,  KC_DD,  KC_FF,  KC_G,        KC_H,  KC_JJ,  KC_KK,    KC_LL,   KC_SCSC,  KC_ENT,
-        KC_LSFT,  KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,        KC_N,  KC_M,   KC_COMM,  KC_DOT,  KC_SLSH,  KC_RSFT,
+        OC_TL,    KC_Q,   KC_W,   KC_E,   KC_R,   KC_T,        KC_Y,  KC_U,   KC_I,     KC_O,    KC_P,     OC_TR,
+        OC_ML,    KC_AA,  KC_SS,  KC_DD,  KC_FF,  KC_G,        KC_H,  KC_JJ,  KC_KK,    KC_LL,   KC_SCSC,  OC_MR,
+        OC_BL,    KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,        KC_N,  KC_M,   KC_COMM,  KC_DOT,  KC_SLSH,  OC_BR,
 
-                 AS_TL_TUCK,  AS_TL_HOME,  AS_TL_REACH,        AS_TR_REACH,  AS_TR_HOME,  AS_TR_TUCK
+               AS_TL_TUCK,  AS_TL_HOME,  AS_TL_REACH,        AS_TR_REACH,  AS_TR_HOME,  AS_TR_TUCK
     ),
 
     // 1. NumLock layer -- sticky NavNum that stays on until deactivated

--- a/selenium/options.h
+++ b/selenium/options.h
@@ -90,3 +90,18 @@
 // Do NOT activate this and then conclude that HRMs "don't work well".
 
 // #define PERMISSIVE_HOLD
+
+/******************************************************************************
+ * Outer Column Keys (42-key boards only)
+ ******************************************************************************/
+
+// On 42-key boards (e.g. Quacken, Corne), these define the 6th column keys on the
+// base layer. Ignored on smaller boards where the outer column doesn't exist.
+// Uncomment and edit to customize. Defaults match the Selenium specification.
+
+// #define OC_TL  KC_TAB
+// #define OC_TR  KC_BSPC
+// #define OC_ML  KC_ESC
+// #define OC_MR  KC_ENT
+// #define OC_BL  KC_LSFT
+// #define OC_BR  KC_RSFT


### PR DESCRIPTION
## Summary

On 42-key boards (e.g. Corne, Quacken), the outer column keys (6th column) are often the first thing users want to customize — replacing Tab, Backspace, Enter, or Shift with media keys, layer access, or other personal preferences.

Today, doing this requires editing `keymap.c` directly, which means either maintaining a personal fork/branch or losing changes on every upstream update. This is a significant barrier for users who are not comfortable with git.

This PR adds 6 configurable macros (`OC_TL`, `OC_TR`, `OC_ML`, `OC_MR`, `OC_BL`, `OC_BR`) that can be customized directly in `options.h` — the same file users already edit to choose their hold-tap variant, enable VIM_NAVIGATION, etc. The pattern is identical: uncomment a line and change the value.

```c
// #define OC_TL  KC_TAB    // default
#define OC_TL  KC_MPLY      // my override: media play on top-left
```

- Defaults match the Selenium specification (Tab, Backspace, Esc, Enter, LShift, RShift)
- On smaller boards (34-36 keys), these keys don't exist in the layout macro and the defines are simply ignored
- No changes to the core 30-key layout or thumb keys

## Test plan

- [x] All 13 per-option compile tests pass (all HT variants, all host layouts)