### PR TITLE
refactor(shared): keymap-shaped facades over ONEDEADKEY_LAYOUT

### DIFF
--- a/arsenik/keymap.c
+++ b/arsenik/keymap.c
@@ -20,10 +20,10 @@ enum custom_keycodes {
     ODK_5,              // ‰
 };
 
-// The ONEDEADKEY_LAYOUT macro allows us to declare a config for a 4x6+3 keyboard, then truncate it
-// (or fill it with noops) depending on the size of your keyboard. Your keyboard may have extra
-// definitions for this macro or none at all (preventing you from compiling the keymap). Check
-// the `README.md` file for more information.
+// The ARSENIK_LAYOUT macro declares a config for a 4x12+6 keyboard (4 rows × 12 cols + 6 thumbs),
+// which the underlying ONEDEADKEY_LAYOUT descriptor (shared/layouts.h) truncates or fills with
+// noops depending on your keyboard's native layout. If your keyboard has no matching branch in
+// shared/layouts.h the build will fail — check `README.md` for supported layouts.
 //
 // A comprehensive list of QMK keycodes is available here: https://docs.qmk.fm/keycodes
 // However, we used a many aliases to automatically adapt the keymap depending on the options you
@@ -33,7 +33,7 @@ enum custom_keycodes {
 // clang-format off
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
-    [_base] = ONEDEADKEY_LAYOUT(
+    [_base] = ARSENIK_LAYOUT(
         KC_CAPS,  KC_1,  KC_2,   KC_3,   KC_4,   KC_5,        KC_6,  KC_7,   KC_8,     KC_9,    KC_0,     KC_DEL,
         KC_TAB,   KC_Q,  KC_W,   KC_E,   KC_R,   KC_T,        KC_Y,  KC_U,   KC_I,     KC_O,    KC_P,     KC_BSPC,
         KC_ESC,   KC_A,  KC_SS,  KC_DD,  KC_FF,  KC_G,        KC_H,  KC_JJ,  KC_KK,    KC_LL,   KC_SCLN,  KC_ENTER,
@@ -42,7 +42,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                 AS_TL_TUCK,  AS_TL_HOME,  AS_TL_REACH,        AS_TR_REACH,  AS_TR_HOME,  AS_TR_TUCK
     ),
 
-    [_symbols] = ONEDEADKEY_LAYOUT(
+    [_symbols] = ARSENIK_LAYOUT(
         __,  AG(KC_1),  AG(KC_2),  AG(KC_3),  AG(KC_4),  AG(KC_5),        AG(KC_6),  AG(KC_7),  AG(KC_8),  AG(KC_9),  AG(KC_0),  __,
         __,  AS(CIRC),  AS(LABK),  AS(RABK),  AS(DLR),   AS(PERC),        AS(AT),    AS(AMPR),  AS(ASTR),  AS(QUOT),  AS(GRV),   __,
         __,  AS(LCBR),  AS(LPRN),  AS(RPRN),  AS(RCBR),  AS(EQL),         AS(BSLS),  AS(PLUS),  AS(MINS),  AS(SLSH),  AS(DQUO),  __,
@@ -52,7 +52,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     ),
 
     // Not fully implemented yet
-    [_num_row] = ONEDEADKEY_LAYOUT(
+    [_num_row] = ARSENIK_LAYOUT(
         __,  __,     __,     __,     __,     __,           __,     __,        __,        __,       __,        __,
         __,  AS_S1,  AS_S2,  AS_S3,  AS_S4,  AS_S5,        AS_S6,  AS_S7,     AS_S8,     AS_S9,    AS_S0,     __,
         __,  AS(1),  AS(2),  AS(3),  AS(4),  AS(5),        AS(6),  AS(7),     AS(8),     AS(9),    AS(0),     __,
@@ -61,7 +61,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                              SYMBOLS,  KC_SPC,  XX,        XX,  KC_SPC,  SYMBOLS
     ),
 
-    [_vim_nav] = ONEDEADKEY_LAYOUT(
+    [_vim_nav] = ARSENIK_LAYOUT(
         __,  G(KC_1),       G(KC_2),   G(KC_3),    G(KC_4),   G(KC_5),        G(KC_6),  G(KC_7),  G(KC_8),  G(KC_9),  G(KC_0),       __,
         __,  MO(_num_nav),  C(AS(T)),  KC_WBAK,    KC_WFWD,   XX,             KC_HOME,  KC_PGDN,  KC_PGUP,  KC_END,   G(AS(P)),      __,
         __,  C(AS(A)),      C(AS(S)),  S(KC_TAB),  KC_TAB,    XX,             KC_LEFT,  KC_DOWN,  KC_UP,    KC_RGHT,  MO(_fun_pad),  __,
@@ -70,7 +70,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                                                      KC_DEL,  __,  XX,        XX,  __,  KC_ESC
     ),
 
-    [_num_nav] = ONEDEADKEY_LAYOUT(
+    [_num_nav] = ARSENIK_LAYOUT(
         __,  G(KC_1),   G(KC_2),   G(KC_3),   G(KC_4),   G(KC_5),          G(KC_6),   G(KC_7),  G(KC_8),  G(KC_9),  G(KC_0),   __,
         __,  KC_TAB,    KC_HOME,   KC_UP,     KC_END,    KC_PGUP,          AS(SLSH),  AS(7),    AS(8),    AS(9),    G(AS(P)),  __,
         __,  C(AS(A)),  KC_LEFT,   KC_DOWN,   KC_RGHT,   KC_PGDN,          AS(MINS),  AS(4),    AS(5),    AS(6),    AS(0),     __,
@@ -79,7 +79,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                                                   KC_DEL,  __,  XX,        XX,  __,  KC_ESC
     ),
 
-    [_fun_pad] = ONEDEADKEY_LAYOUT(
+    [_fun_pad] = ARSENIK_LAYOUT(
         __,  __,     __,      __,      __,      __,        __,  __,       __,       __,       __,  __,
         __,  KC_F1,  KC_F2,   KC_F3,   KC_F4,   XX,        XX,  XX,       XX,       XX,       XX,  __,
         __,  KC_F5,  KC_F6,   KC_F7,   KC_F8,   XX,        XX,  KC_LCTL,  KC_LALT,  KC_LGUI,  __,  __,

--- a/selenium/keymap.c
+++ b/selenium/keymap.c
@@ -42,12 +42,13 @@ enum custom_keycodes {
 // QMK implementation of the Selenium specification.
 // Thumb keys are configurable via HT_*, VIM_NAVIGATION, and LEFT_HAND_SPACE
 // options in options.h. See internals.h for the thumb key definitions.
+// Selenium is a 42-key spec: physical row 1 (if present on the board) is
+// transparent on every layer — injected by the SELENIUM_LAYOUT facade.
 // clang-format off
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 
     // 0. Base layer
-    [_base] = ONEDEADKEY_LAYOUT(
-        __,       __,     __,     __,     __,     __,          __,    __,     __,       __,      __,       __,
+    [_base] = SELENIUM_LAYOUT(
         KC_TAB,   KC_Q,   KC_W,   KC_E,   KC_R,   KC_T,        KC_Y,  KC_U,   KC_I,     KC_O,    KC_P,     KC_BSPC,
         KC_ESC,   KC_AA,  KC_SS,  KC_DD,  KC_FF,  KC_G,        KC_H,  KC_JJ,  KC_KK,    KC_LL,   KC_SCSC,  KC_ENT,
         KC_LSFT,  KC_Z,   KC_X,   KC_C,   KC_V,   KC_B,        KC_N,  KC_M,   KC_COMM,  KC_DOT,  KC_SLSH,  KC_RSFT,
@@ -56,8 +57,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     ),
 
     // 1. NumLock layer -- sticky NavNum that stays on until deactivated
-    [_num_lock] = ONEDEADKEY_LAYOUT(
-        __,  __,        __,        __,        __,        __,              __,         __,     __,     __,     __,        __,
+    [_num_lock] = SELENIUM_LAYOUT(
         __,  KC_ESC,    KC_HOME,   KC_UP,     KC_END,    KC_PGUP,         TO(_base),  AS(7),  AS(8),  AS(9),  AS(SLSH),  __,
         __,  AS(EQL),   KC_LEFT,   KC_DOWN,   KC_RGHT,   KC_PGDN,         AS(MINS),   AS(4),  AS(5),  AS(6),  AS(0),     __,
         __,  AS_MONEY,  AS(COLN),  AS(ASTR),  AS(PLUS),  AS(PERC),        AS(COMM),   AS(1),  AS(2),  AS(3),  AS(DOT),   __,
@@ -66,8 +66,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     ),
 
     // 2. Symbols layer -- programming symbols (AltGr layer for Ergol)
-    [_symbols] = ONEDEADKEY_LAYOUT(
-        __,  __,        __,        __,        __,        __,              __,        __,        __,        __,        __,        __,
+    [_symbols] = SELENIUM_LAYOUT(
         __,  AS(CIRC),  AS(LABK),  AS(RABK),  AS(DLR),   AS(PERC),        AS(AT),    AS(AMPR),  AS(ASTR),  AS(QUOT),  AS(GRV),   __,
         __,  AS(LCBR),  AS(LPRN),  AS(RPRN),  AS(RCBR),  AS(EQL),         AS(BSLS),  AS(PLUS),  AS(MINS),  AS(SLSH),  AS(DQUO),  __,
         __,  TILDE,     AS(LBRC),  AS(RBRC),  AS(UNDS),  AS(HASH),        AS(PIPE),  AS(EXLM),  AS(SCLN),  AS(COLN),  AS(QUES),  __,
@@ -76,8 +75,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     ),
 
     // 3. VimNav layer -- HJKL arrow cluster + GUI shortcuts (not accessible by default)
-    [_vim_nav] = ONEDEADKEY_LAYOUT(
-        __,  __,       __,        __,          __,          __,             __,       __,       __,       __,       __,      __,
+    [_vim_nav] = SELENIUM_LAYOUT(
         __,  XX,       SC_CTL_W,  SC_PREV,     SC_NEXT,     XX,             KC_HOME,  KC_PGDN,  KC_PGUP,  KC_END,   KC_DEL,  __,
         __,  SC_ALL,   SC_SAVE,   S(KC_TAB),   KC_TAB,      XX,             KC_LEFT,  KC_DOWN,  KC_UP,    KC_RGHT,  XX,      __,
         __,  SC_UNDO,  SC_CUT,    SC_COPY,     SC_PASTE,    SC_REDO,        XX,       XX,       XX,       XX,       XX,      __,
@@ -86,8 +84,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     ),
 
     // 4. NavNum layer -- inverted T navigation + numpad
-    [_nav_num] = ONEDEADKEY_LAYOUT(
-        __,  __,       __,       __,       __,        __,             __,             __,     __,     __,     __,        __,
+    [_nav_num] = SELENIUM_LAYOUT(
         __,  KC_ESC,   KC_HOME,  KC_UP,    KC_END,    KC_PGUP,        TO(_num_lock),  AS(7),  AS(8),  AS(9),  AS(SLSH),  __,
         __,  SC_ALL,   KC_LEFT,  KC_DOWN,  KC_RGHT,   KC_PGDN,        AS(MINS),       AS(4),  AS(5),  AS(6),  AS(0),     __,
         __,  SC_UNDO,  SC_CUT,   SC_COPY,  SC_PASTE,  SC_REDO,        AS(COMM),       AS(1),  AS(2),  AS(3),  AS(DOT),   __,
@@ -96,8 +93,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     ),
 
     // 5. NumRow layer -- numbers on homerow (not accessible by default)
-    [_num_row] = ONEDEADKEY_LAYOUT(
-        __,  __,     __,     __,     __,     __,           __,        __,        __,       __,        __,        __,
+    [_num_row] = SELENIUM_LAYOUT(
         __,  AS_S1,  AS_S2,  AS_S3,  AS_S4,  AS_S5,        AS_S6,     AS_S7,     AS_S8,    AS_S9,     AS_S0,     __,
         __,  AS(1),  AS(2),  AS(3),  AS(4),  AS(5),        AS(6),     AS(7),     AS(8),    AS(9),     AS(0),     __,
         __,  XX,     XX,     XX,     XX,     XX,           AS(MINS),  AS(COMM),  AS(DOT),  AS(COLN),  AS(SLSH),  __,
@@ -106,8 +102,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     ),
 
     // 6. FnMedia layer -- F1..12 + media controls + modifiers on right homerow
-    [_fn_media] = ONEDEADKEY_LAYOUT(
-        __,  __,     __,      __,      __,      __,        __,  __,               __,               __,       __,               __,
+    [_fn_media] = SELENIUM_LAYOUT(
         __,  KC_F1,  KC_F2,   KC_F3,   KC_F4,   XX,        XX,  KC_MPRV,          KC_VOLU,          KC_BRIU,  KC_SCRL,          __,
         __,  KC_F5,  KC_F6,   KC_F7,   KC_F8,   XX,        XX,  _ALT_T(KC_MPLY),  _CTL_T(KC_MUTE),  _GUI_T(KC_NO),  LSFT_T(KC_PSCR),  __,
         __,  KC_F9,  KC_F10,  KC_F11,  KC_F12,  XX,        XX,  KC_MNXT,          KC_VOLD,          KC_BRID,  KC_INS,           __,

--- a/shared/layouts.h
+++ b/shared/layouts.h
@@ -3,7 +3,37 @@
 #pragma once
 
 // ╭─────────────────────────────────────────────────────────╮
-// │                 QMK layouts definitions                 │
+// │          Keymap facades over ONEDEADKEY_LAYOUT          │
+// ╰─────────────────────────────────────────────────────────╯
+
+#define ARSENIK_LAYOUT(\
+    k11, k12, k13, k14, k15, k16,     k17, k18, k19, k1a, k1b, k1c,\
+    k21, k22, k23, k24, k25, k26,     k27, k28, k29, k2a, k2b, k2c,\
+    k31, k32, k33, k34, k35, k36,     k37, k38, k39, k3a, k3b, k3c,\
+    k41, k42, k43, k44, k45, k46,     k47, k48, k49, k4a, k4b, k4c,\
+                   k51, k52, k53,     k54, k55, k56\
+) ONEDEADKEY_LAYOUT(\
+    k11, k12, k13, k14, k15, k16,     k17, k18, k19, k1a, k1b, k1c,\
+    k21, k22, k23, k24, k25, k26,     k27, k28, k29, k2a, k2b, k2c,\
+    k31, k32, k33, k34, k35, k36,     k37, k38, k39, k3a, k3b, k3c,\
+    k41, k42, k43, k44, k45, k46,     k47, k48, k49, k4a, k4b, k4c,\
+                   k51, k52, k53,     k54, k55, k56)
+
+// Row 1 is not part of Selenium's 42-key spec; the facade fills its 12 slots with `__`.
+#define SELENIUM_LAYOUT(\
+    LOUT1, L21, L22, L23, L24, L25,     R21, R22, R23, R24, R25, ROUT1,\
+    LOUT2, L31, L32, L33, L34, L35,     R31, R32, R33, R34, R35, ROUT2,\
+    LOUT3, L41, L42, L43, L44, L45,     R41, R42, R43, R44, R45, ROUT3,\
+                     LT1, LT2, LT3,     RT3, RT2, RT1\
+) ONEDEADKEY_LAYOUT(\
+    __,    __,  __,  __,  __,  __,      __,  __,  __,  __,  __,  __,\
+    LOUT1, L21, L22, L23, L24, L25,     R21, R22, R23, R24, R25, ROUT1,\
+    LOUT2, L31, L32, L33, L34, L35,     R31, R32, R33, R34, R35, ROUT2,\
+    LOUT3, L41, L42, L43, L44, L45,     R41, R42, R43, R44, R45, ROUT3,\
+                     LT1, LT2, LT3,     RT3, RT2, RT1)
+
+// ╭─────────────────────────────────────────────────────────╮
+// │     Physical descriptors — ONEDEADKEY_LAYOUT per board  │
 // ╰─────────────────────────────────────────────────────────╯
 
 //  ──────────────────────────< Generic layouts >──────────────────────────


### PR DESCRIPTION
add two named facades over ONEDEADKEY_LAYOUT : 

- ARSENIK_LAYOUT — 54 args, identity facade.
- SELENIUM_LAYOUT — 42 args (outer columns + main rows + thumbs), injects __ (aka `KC_TRNS`) for the 12 row-1 slots it doesn't carry.
