### PR TITLE
Add Keyboard.io atreus support

### DIFF
--- a/shared/layouts.h
+++ b/shared/layouts.h
@@ -346,6 +346,44 @@
         ODK_EXT_THUMB_FAR_L, ODK_EXT_THUMB_OUT_L, k51, k52, k53,     k54, k55, k56, ODK_EXT_THUMB_OUT_R, ODK_EXT_THUMB_FAR_R\
     )
 
+#elif defined(ONEDEADKEY_LAYOUT_keyboardio_atreus)
+#ifndef ODK_EXT_INNER_L
+#    define ODK_EXT_INNER_L KC_NO
+#endif
+#ifndef ODK_EXT_INNER_R
+#    define ODK_EXT_INNER_R KC_NO
+#endif
+#ifndef ODK_EXT_THUMB_OUT_L
+#    define ODK_EXT_THUMB_OUT_L KC_NO
+#endif
+#ifndef ODK_EXT_THUMB_OUT_R
+#    define ODK_EXT_THUMB_OUT_R KC_NO
+#endif
+#ifndef ODK_EXT_THUMB_FAR_L
+#    define ODK_EXT_THUMB_FAR_L KC_NO
+#endif
+#ifndef ODK_EXT_THUMB_FAR_R
+#    define ODK_EXT_THUMB_FAR_R KC_NO
+#endif
+#ifndef ODK_EXT_THUMB_FAR_EXT_L
+#    define ODK_EXT_THUMB_FAR_EXT_L KC_NO
+#endif
+#ifndef ODK_EXT_THUMB_FAR_EXT_R
+#    define ODK_EXT_THUMB_FAR_EXT_R KC_NO
+#endif
+#define ONEDEADKEY_LAYOUT(\
+        k11, k12, k13, k14, k15, k16,     k17, k18, k19, k1a, k1b, k1c,\
+        k21, k22, k23, k24, k25, k26,     k27, k28, k29, k2a, k2b, k2c,\
+        k31, k32, k33, k34, k35, k36,     k37, k38, k39, k3a, k3b, k3c,\
+        k41, k42, k43, k44, k45, k46,     k47, k48, k49, k4a, k4b, k4c,\
+                       k51, k52, k53,     k54, k55, k56\
+    ) LAYOUT(\
+        k22, k23, k24, k25, k26,                                   k27, k28, k29, k2a, k2b,\
+        k32, k33, k34, k35, k36,                                   k37, k38, k39, k3a, k3b,\
+        k42, k43, k44, k45, k46, ODK_EXT_INNER_L, ODK_EXT_INNER_R, k47, k48, k49, k4a, k4b,\
+        ODK_EXT_THUMB_FAR_EXT_L, ODK_EXT_THUMB_FAR_L, ODK_EXT_THUMB_OUT_L, k51, k52, k53, k54, k55, k56, ODK_EXT_THUMB_OUT_R, ODK_EXT_THUMB_FAR_R, ODK_EXT_THUMB_FAR_EXT_R\
+    )
+
 #else
 #    error "Arsenik: Unknown layout"
 #endif

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -26,6 +26,12 @@ log_fail()    { echo -e "${RED}[FAIL]${NC} $1"; FAIL=$((FAIL + 1)); FAILED_TESTS
 log_skip()    { echo -e "${YELLOW}[SKIP]${NC} $1"; SKIP=$((SKIP + 1)); }
 log_section() { echo -e "\n${CYAN}═══ $1 ═══${NC}"; }
 
+# Recent milc versions (qmk's CLI framework) annotate values with a trailing
+# provenance marker like " (config)", " (env)", " (default)"; strip any such suffix.
+qmk_config_value() {
+    qmk config "$1" | awk -F= '{print $2}' | sed -E 's/ \([a-z_]+\)$//' | xargs
+}
+
 # ─────────────────────────────────────────────────────────────
 # Environment setup
 # ─────────────────────────────────────────────────────────────
@@ -35,11 +41,11 @@ setup_env() {
     JOBS="${JOBS:-0}"
 
     if [ -z "$KEYBOARD" ]; then
-        KEYBOARD=$(qmk config user.keyboard | awk -F= '{print $2}' | xargs)
+        KEYBOARD=$(qmk_config_value user.keyboard)
     fi
 
     if [ -z "${QMK_HOME+x}" ]; then
-        QMK_HOME=$(qmk config user.qmk_home | awk -F= '{print $2}' | xargs)
+        QMK_HOME=$(qmk_config_value user.qmk_home)
         # Expand $HOME if envsubst is available, otherwise use eval
         if command -v envsubst > /dev/null 2>&1; then
             QMK_HOME=$(echo "$QMK_HOME" | envsubst)


### PR DESCRIPTION
The layout is using the thumb keys highlighted in yellow in the picture below:
<img width="706" height="257" alt="image" src="https://github.com/user-attachments/assets/145d9676-a098-4369-8743-8dea3f2a98d5" />

I did not rebase to avoid breaking the commit IDs referenced in the issue, but I could do it if deemed necessary.
If anything is missing, please let me know and I’ll do my best to correct this.