### PR TITLE
refactor(generator): layout detection rely on qmk info

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
 QMK_VERSION=0.32.3
 QMK_KEYBOARD=beekeeb/piantor
+QMK_LAYOUT=LAYOUT_split_3x6_3

--- a/.github/workflows/qmk-test.yml
+++ b/.github/workflows/qmk-test.yml
@@ -27,6 +27,7 @@ jobs:
           . $GITHUB_WORKSPACE/.env
           echo "QMK_VERSION=$QMK_VERSION" >> $GITHUB_ENV
           echo "QMK_KEYBOARD=$QMK_KEYBOARD" >> $GITHUB_ENV
+          echo "QMK_LAYOUT=$QMK_LAYOUT" >> $GITHUB_ENV
 
       - name: Setup QMK firmware
         run: qmk setup -y -b $QMK_VERSION
@@ -38,7 +39,7 @@ jobs:
           qmk config user.qmk_home=$QMK_HOME
 
       - name: Compile per-option tests
-        run: bash $GITHUB_WORKSPACE/tests/test_per_option.sh -target ${{ matrix.target }} -kb $QMK_KEYBOARD -j 0
+        run: bash $GITHUB_WORKSPACE/tests/test_per_option.sh -target ${{ matrix.target }} -kb $QMK_KEYBOARD -layout $QMK_LAYOUT -j 0
 
   compile-exhaustive:
     name: Compile exhaustive (${{ matrix.target }})
@@ -60,6 +61,7 @@ jobs:
           . $GITHUB_WORKSPACE/.env
           echo "QMK_VERSION=$QMK_VERSION" >> $GITHUB_ENV
           echo "QMK_KEYBOARD=$QMK_KEYBOARD" >> $GITHUB_ENV
+          echo "QMK_LAYOUT=$QMK_LAYOUT" >> $GITHUB_ENV
 
       - name: Setup QMK firmware
         run: qmk setup -y -b $QMK_VERSION
@@ -71,4 +73,4 @@ jobs:
           qmk config user.qmk_home=$QMK_HOME
 
       - name: Compile exhaustive tests
-        run: bash $GITHUB_WORKSPACE/tests/test_exhaustive.sh -target ${{ matrix.target }} -kb $QMK_KEYBOARD -j 0
+        run: bash $GITHUB_WORKSPACE/tests/test_exhaustive.sh -target ${{ matrix.target }} -kb $QMK_KEYBOARD -layout $QMK_LAYOUT -j 0

--- a/README.md
+++ b/README.md
@@ -9,46 +9,39 @@
 
 ## Getting started
 
-### 1. Install QMK
+### 1. Install QMK and jq
 
-Follow the [QMK getting started guide](https://docs.qmk.fm/newbs_getting_started) for your OS, then:
+Install QMK and its CLI by following the [QMK getting started guide](https://docs.qmk.fm/newbs_getting_started) for your OS.
+You also need [jq](https://jqlang.org/) (used by the generator for layout detection).
 
-```bash
-# Install the QMK CLI (pick one)
-uv tool install qmk
-pipx install qmk
-python3 -m pip install qmk
-
-# Setup - it clones the QMK firmware repository (~1.5 GB) into `$HOME/qmk_firmware`
-qmk setup
-```
-
-Then check the value of `qmk config user.qmk_home`, it should return:
+Then check that `qmk config user.qmk_home` resolves to an absolute path on your system:
 
 ```sh
-user.qmk_home=~/qmk_firmware
+qmk config user.qmk_home
 ```
 
-> **Note 1:** If you've already cloned the QMK firmware repository elsewhere in your system (not in the default `$HOME/qmk_firmware`),
-> you may set `qmk_home` to the path of your existing clone: `qmk config user.qmk_home="~/path/to/qmk_firmware"`
+If it's empty, point it at your QMK firmware clone:
 
-> **Note 2:** If `qmk config` shows a literal `$HOME/...` instead of an expanded path, see [Setting `user.qmk_home`](#setting-userqmk_home) in the Reference section.
+```bash
+qmk config user.qmk_home="~/path/to/qmk_firmware"
+```
+
+> **Note:** If `qmk config` shows a literal `$HOME/...` instead of an expanded path, see [Setting `user.qmk_home`](#setting-userqmk_home) in the Reference section.
 
 ### 2. Configure QMK for your keyboard
 
-Tell QMK which keyboard and keymap to use. To find your keyboard's QMK name:
+Tell QMK which keyboard you're using. To find your keyboard's QMK name:
 
 ```bash
-qmk list-keyboards | grep <your keyboard>
-qmk info -kb <keyboard_model>
+# example for piantor
+qmk list-keyboards | grep piantor
 ```
 
 Then configure it (replace `beekeeb/piantor` with your model):
 
 ```bash
-# set your config values
+# set your keyboard
 qmk config user.keyboard=beekeeb/piantor
-qmk config user.keymap=default
 
 # check your config
 qmk config
@@ -63,34 +56,37 @@ cd qmk-config-aekeynox
 
 ### 4. Customize (optional)
 
-Each keymap has an `options.h` file where you can configure host layout, hold-tap behavior, and other features. Each option is documented with inline comments. Edit this file **before** generating your keymap.
+Each keymap has an `options.h` file where you can configure host layout, hold-tap behavior, and other features.
+Each option is documented with inline comments. Edit this file **before** generating your keymap.
 
 The defaults work out of the box — you can skip this step and come back later.
 
 ### 5. Generate the keymap and copy it to QMK
 
-The generator assembles a keymap from a source folder + shared headers, adapts
-it to your keyboard's physical layout, and writes the result to
-`./output/<keyboard>/keymaps/<name>`. The `--copy` flag additionally drops the
-output into `$QMK_HOME/keyboards/<keyboard>/keymaps/<name>` so QMK can find it.
+Run the generator to build your keymap. The `--copy` flag installs it into
+QMK so it can be compiled and flashed from there; without `--copy`, the
+keymap is only written to `./output/` (useful for previewing before
+installing).
+
+If a QMK keyboard reference declares several physical variants, the
+generator will ask you to pick the one matching your actual board — refer
+to your keyboard's specs (key count, inner column, thumb cluster shape) to
+choose. Pass `-layout <LAYOUT_NAME>` to skip the prompt.
 
 ```bash
 ./generator.sh -src ./selenium --copy
 ```
 
-This uses `user.keyboard` and `user.keymap` from `qmk config` (set in Step 2)
-to pick the keyboard and auto-detect the physical layout.
-
 Other useful invocations:
 
 ```bash
-# Generate only — preview the output without touching $QMK_HOME
+# Generate only — preview without installing into QMK
 ./generator.sh -src ./selenium
 
 # Pick a keyboard explicitly (ignores user.keyboard)
 ./generator.sh -src ./selenium -kb beekeeb/piantor --copy
 
-# Force a specific physical layout (skips auto-detection from -km)
+# Force a specific physical layout (skip the variant prompt)
 ./generator.sh -src ./selenium -layout LAYOUT_split_3x6_3_ex2 --copy
 
 # Full flag list
@@ -100,11 +96,11 @@ Other useful invocations:
 ### 6. Compile and flash
 
 ```bash
-# Compile the firmware
-qmk compile -km selenium
+# Compile the firmware (replace `selenium` with `arsenik` if you generated Arsenik)
+qmk compile -kb beekeeb/piantor -km selenium
 
 # Connect your keyboard, then flash
-qmk flash -km selenium
+qmk flash -kb beekeeb/piantor -km selenium
 ```
 
 The keyboard enters flash mode differently depending on the board — check your keyboard's documentation (usually a reset button or a key combination).
@@ -113,9 +109,8 @@ The keyboard enters flash mode differently depending on the board — check your
 
 ### Setting `user.qmk_home`
 
-`qmk config` stores the value verbatim, then later expands a leading `~` but
-**not** `$HOME`. Whether a form works therefore depends on what your shell did
-with the value before `qmk` saw it.
+`qmk config` stores the value verbatim, then later expands a leading `~` but **not** `$HOME`.
+Whether a form works therefore depends on what your shell did with the value before `qmk` saw it.
 
 Works:
 
@@ -136,7 +131,7 @@ After setting, run `qmk config` and verify the value resolves to an absolute pat
 
 ### Supported keyboards
 
-The keymaps use a `ONEDEADKEY_LAYOUT` macro that adapts automatically to different keyboard sizes and shapes. The following physical layouts are supported:
+The following physical layouts are supported:
 
 - `LAYOUT_split_3x5_2`
 - `LAYOUT_split_3x5_3`
@@ -156,7 +151,8 @@ If your keyboard is not listed, you can add its layout to `shared/layouts.h` or 
 
 #### Lily58 (58 keys, 5 rows + 4 thumbs per side)
 
-Lily58 has **4 keys beyond** the 42-key Selenium/Arsenik spec: 1 inner-corner key per side (below the home row) and 1 extra outermost thumb per side. They default to `KC_NO` (inert). Override in your keymap's `options.h`:
+Lily58 has **4 keys beyond** the 42-key Selenium/Arsenik spec: 1 inner-corner key per side (below the home row) and 1 extra outermost thumb per side.
+They default to `KC_NO` (inert). Override in your keymap's `options.h`:
 
 ```c
 #define ODK_EXT_INNER_L     KC_LBRC  // left  inner corner
@@ -165,11 +161,14 @@ Lily58 has **4 keys beyond** the 42-key Selenium/Arsenik spec: 1 inner-corner ke
 #define ODK_EXT_THUMB_OUT_R KC_RCTL  // right outermost thumb
 ```
 
-**Selenium caveat:** Selenium is a 42-key spec, so logical row 1 (the top row) is transparent on every layer. On Lily58 with Selenium, the physical number row emits nothing until you edit `selenium/keymap.c` row 1 locally. **Arsenik is unaffected** — its base layer uses the top row for numbers natively.
+**Selenium caveat:** Selenium is a 42-key spec, so logical row 1 (the top row) is transparent on every layer.
+On Lily58 with Selenium, the physical number row emits nothing until you edit `selenium/keymap.c` row 1 locally.
+**Arsenik is unaffected** — its base layer uses the top row for numbers natively.
 
 #### Sofle (60 keys, Lily58 + 1 extra outermost thumb per side)
 
-Sofle adds **2 more keys** to the Lily58 layout — an extra outermost thumb per side (matrix `[4,0]` left, `[9,0]` right). On most Sofle builds, that position is a rotary encoder press.
+Sofle adds **2 more keys** to the Lily58 layout — an extra outermost thumb per side (matrix `[4,0]` left, `[9,0]` right).
+On most Sofle builds, that position is a rotary encoder press.
 
 Everything from the Lily58 section applies, plus two more override slots:
 
@@ -180,11 +179,14 @@ Everything from the Lily58 section applies, plus two more override slots:
 
 The same Selenium top-row caveat applies.
 
-**Note for `keebart/sofle_choc_pro` users:** that board exposes `LAYOUT_split_4x6_5` (a community layout name) rather than a Sofle-specific one. Auto-detection would produce `ONEDEADKEY_LAYOUT_split_4x6_5`, which is intentionally not matched (the community name has a different meaning on other keyboards). Generate with `-layout LAYOUT_sofle` to force the Sofle branch.
+**Note for `keebart/sofle_choc_pro` users:** that board exposes `LAYOUT_split_4x6_5` (a community layout name) rather than a Sofle-specific one.
+Auto-detection would produce `ONEDEADKEY_LAYOUT_split_4x6_5`, which is intentionally not matched (the community name has a different meaning on other keyboards).
+Generate with `-layout LAYOUT_sofle` to force the Sofle layout.
 
 #### Inner-column extensions (`_ex2` layouts)
 
-Boards like the Corne v4 expose an `_ex2` variant with **4 extra physical keys** — 2 per side, stacked as a short inner column on the top and middle rows. These keys are outside the Selenium/Arsenik spec, so they default to `KC_NO` (inert).
+Boards like the Corne v4 expose an `_ex2` variant with **4 extra physical keys** — 2 per side, stacked as a short inner column on the top and middle rows.
+These keys are outside the Selenium/Arsenik spec, so they default to `KC_NO` (inert).
 
 To bind them, add to your keymap's `options.h` before generating:
 
@@ -200,19 +202,22 @@ The bound keycode is the same across all layers.
 ### Generator options
 
 ```bash
-./generator.sh -src <keymap_folder> [-kb <keyboard>] [-km <ref_keymap>] [-layout <LAYOUT>] [-name <name>] [--copy]
+./generator.sh -src <keymap_folder> [-kb <keyboard_model>] [-layout <LAYOUT>] [-name <target_name>] [--copy]
 ```
 
-| Flag               | Description                                                                          |
-| ------------------ | ------------------------------------------------------------------------------------ |
-| `-src <path>`      | Path to the keymap source folder (required)                                          |
-| `-kb <keyboard>`   | Keyboard model (default: from `qmk config`)                                          |
-| `-km <keymap>`     | Reference keymap for layout auto-detection (default: from `qmk config`)              |
-| `-layout <LAYOUT>` | Explicit LAYOUT macro (e.g. `LAYOUT_split_3x6_3_ex2`). Skips detection; `-km` unused |
-| `-name <name>`     | Name for the generated keymap (default: source folder name)                          |
-| `--copy`, `-cp`    | Copy output to `$QMK_HOME` after generating                                          |
+| Flag                   | Description                                                                     |
+| ---------------------- | ------------------------------------------------------------------------------- |
+| `-src <path>`          | Path to the keymap source folder (required)                                     |
+| `-kb <keyboard_model>` | Keyboard model (default: from `qmk config user.keyboard`)                       |
+| `-layout <LAYOUT>`     | Explicit LAYOUT macro override (e.g. `LAYOUT_split_3x6_3_ex2`); skips detection |
+| `-name <target_name>`  | Name for the generated keymap (default: source folder name)                     |
+| `--copy`, `-cp`        | Copy output to `$QMK_HOME` after generating                                     |
 
-Use `-layout` when the keyboard exposes multiple physical variants (e.g. `crkbd/rev4_0` has both `LAYOUT_split_3x6_3` and `LAYOUT_split_3x6_3_ex2`) and the reference keymap doesn't use the one you want.
+The generator infers the physical layout from `qmk info -kb <keyboard>` by intersecting the board's `layouts` field with the layouts supported by `shared/layouts.h`.
+When the intersection contains a single layout, it is used silently. When several qualify (e.g. `crkbd/rev1` exposes both `LAYOUT_split_3x5_3` and `LAYOUT_split_3x6_3`),
+the generator prompts you to choose; the default (Enter) is the largest by key count.
+In non-interactive contexts (piped invocations, scripts) the prompt is unavailable, so the generator refuses to guess and requires `-layout` explicitly.
+Pass `-layout` to disambiguate without the prompt. When none qualify, the generator fails with the list of layouts the board exposes so a matching one can be added to `shared/layouts.h`.
 
 ### Formatting
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Each option is documented with inline comments. Edit this file **before** genera
 
 The defaults work out of the box — you can skip this step and come back later.
 
+> **Boards with extra keys** (Lily58, Sofle, Corne v4, cornifi, Atreus) leave the extras inert by default. See [docs/supported_keyboards.md](docs/supported_keyboards.md) for the `ODK_EXT_*` override macros that bind them.
+
 ### 5. Generate the keymap and copy it to QMK
 
 Run the generator to build your keymap. The `--copy` flag installs it into
@@ -131,73 +133,23 @@ After setting, run `qmk config` and verify the value resolves to an absolute pat
 
 ### Supported keyboards
 
-The following physical layouts are supported:
+Any QMK keyboard with a compatible physical layout works:
 
-- `LAYOUT_split_3x5_2`
-- `LAYOUT_split_3x5_3`
-- `LAYOUT_split_3x5_3_ex2` (4 extra inner-column keys — see below)
-- `LAYOUT_split_3x6_3`
-- `LAYOUT_split_3x6_3_ex2` (4 extra inner-column keys — see below)
-- `LAYOUT_ortho_4x10`
-- `LAYOUT_ortho_4x12`
-- `LAYOUT_ortho_5x10`
-- `LAYOUT_ortho_5x12`
-- `LAYOUT_planck_grid`
-- `LAYOUT_keebio_iris`
-- `LAYOUT` on Lily58 (all variants: `rev1`, `light`, `lite_rev3`, `glow_enc`, `r2g` — see below)
-- `LAYOUT` on Sofle (all variants: `sofle/rev1`, `sofle/keyhive`, `sofle_choc`, `sofle_pico`, `splitkb/aurora/sofle_v2`, `mechboards/sofle/pro`, `keebart/sofle_choc_pro` — see below)
+- 32-key splits (3×5, 2 thumbs)
+- 36-key splits (3×5, 3 thumbs) — Ferris, Corne (3×5)
+- 40-key splits, inner column — cornifi → see [docs](docs/supported_keyboards.md#inner-column-extensions-_ex2-layouts)
+- 42-key splits (3×6, 3 thumbs) — Corne (crkbd), Piantor
+- 46-key splits, inner column — Corne v4 → see [docs](docs/supported_keyboards.md#inner-column-extensions-_ex2-layouts)
+- 40-key ortho (4×10)
+- 48-key ortho (4×12) — Planck (incl. grid), Preonic-likes
+- 50-key ortho (5×10)
+- 60-key ortho (5×12)
+- Iris (keebio)
+- Atreus (keyboardio) → see [docs](docs/supported_keyboards.md#atreus)
+- Lily58 (all revs) → see [docs](docs/supported_keyboards.md#lily58)
+- Sofle (all revs incl. `keebart/sofle_choc_pro`) → see [docs](docs/supported_keyboards.md#sofle)
 
 If your keyboard is not listed, you can add its layout to `shared/layouts.h` or [open an issue](https://github.com/OneDeadKey/qmk-config-aekeynox/issues) for help.
-
-#### Lily58 (58 keys, 5 rows + 4 thumbs per side)
-
-Lily58 has **4 keys beyond** the 42-key Selenium/Arsenik spec: 1 inner-corner key per side (below the home row) and 1 extra outermost thumb per side.
-They default to `KC_NO` (inert). Override in your keymap's `options.h`:
-
-```c
-#define ODK_EXT_INNER_L     KC_LBRC  // left  inner corner
-#define ODK_EXT_INNER_R     KC_RBRC  // right inner corner
-#define ODK_EXT_THUMB_OUT_L KC_LCTL  // left  outermost thumb
-#define ODK_EXT_THUMB_OUT_R KC_RCTL  // right outermost thumb
-```
-
-**Selenium caveat:** Selenium is a 42-key spec, so logical row 1 (the top row) is transparent on every layer.
-On Lily58 with Selenium, the physical number row emits nothing until you edit `selenium/keymap.c` row 1 locally.
-**Arsenik is unaffected** — its base layer uses the top row for numbers natively.
-
-#### Sofle (60 keys, Lily58 + 1 extra outermost thumb per side)
-
-Sofle adds **2 more keys** to the Lily58 layout — an extra outermost thumb per side (matrix `[4,0]` left, `[9,0]` right).
-On most Sofle builds, that position is a rotary encoder press.
-
-Everything from the Lily58 section applies, plus two more override slots:
-
-```c
-#define ODK_EXT_THUMB_FAR_L KC_MUTE  // left  outermost thumb (encoder press)
-#define ODK_EXT_THUMB_FAR_R KC_MPLY  // right outermost thumb (encoder press)
-```
-
-The same Selenium top-row caveat applies.
-
-**Note for `keebart/sofle_choc_pro` users:** that board exposes `LAYOUT_split_4x6_5` (a community layout name) rather than a Sofle-specific one.
-Auto-detection would produce `ONEDEADKEY_LAYOUT_split_4x6_5`, which is intentionally not matched (the community name has a different meaning on other keyboards).
-Generate with `-layout LAYOUT_sofle` to force the Sofle layout.
-
-#### Inner-column extensions (`_ex2` layouts)
-
-Boards like the Corne v4 expose an `_ex2` variant with **4 extra physical keys** — 2 per side, stacked as a short inner column on the top and middle rows.
-These keys are outside the Selenium/Arsenik spec, so they default to `KC_NO` (inert).
-
-To bind them, add to your keymap's `options.h` before generating:
-
-```c
-#define ODK_EXT_LT KC_TAB   // left  inner-top
-#define ODK_EXT_LB KC_LCTL  // left  inner-middle
-#define ODK_EXT_RT KC_BSPC  // right inner-top
-#define ODK_EXT_RB KC_RSFT  // right inner-middle
-```
-
-The bound keycode is the same across all layers.
 
 ### Generator options
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,21 @@ Any QMK keyboard with a compatible physical layout works:
 
 If your keyboard is not listed, you can add its layout to `shared/layouts.h` or [open an issue](https://github.com/OneDeadKey/qmk-config-aekeynox/issues) for help.
 
+#### Boards not in mainline QMK
+
+Keyboards missing from mainline QMK may still be supported by a fork. The setup is fork-specific; the Keebart fork below is a worked example.
+
+[`vial-kb/vial-qmk`](https://github.com/vial-kb/vial-qmk) is another fork worth checking — it adds ~150 boards. Layout-compatible candidates include `bastardkb/charybdis` (3×5/3×6 variants), `beekeeb/piantor` controller variants, and Lily58-shaped boards. None tested from this repo.
+
+##### Keebart fork
+
+[`Keebart/vial-qmk-keebart`](https://github.com/Keebart/vial-qmk-keebart) carries Keebart's own product line:
+
+- Corne Choc Pro
+- Corne MX Pro
+
+See [`docs/keebart_keyboards.md`](docs/keebart_keyboards.md) for the setup recipe and per-variant build targets.
+
 ### Generator options
 
 ```bash

--- a/docs/keebart_keyboards.md
+++ b/docs/keebart_keyboards.md
@@ -1,0 +1,91 @@
+# Keebart keyboards
+
+Keebart sells split keyboards that are not all in mainline QMK. Building aekeynox for them requires switching `qmk_home` to [`Keebart/vial-qmk-keebart`](https://github.com/Keebart/vial-qmk-keebart).
+
+Upstream chain: `qmk/qmk_firmware` ← `vial-kb/vial-qmk` ← `Keebart/vial-qmk-keebart` (default branch `vial`).
+
+> **Tested:** `keebart/corne_choc_pro` (verified built and flashed).
+> **Untested:** `keebart/corne_mx_pro` — listed here for completeness based on the fork's keyboard definitions; not built or flashed from this repo.
+
+## Boards covered
+
+| Target                            | Default layout       | Notes                                                                                        |
+| --------------------------------- | -------------------- | -------------------------------------------------------------------------------------------- |
+| `keebart/corne_choc_pro/mini`     | `LAYOUT_split_3x5_3` | Single layout, auto-detected.                                                                |
+| `keebart/corne_choc_pro/standard` | `LAYOUT_split_3x6_3` | Single layout, auto-detected.                                                                |
+| `keebart/corne_mx_pro/mini`       | _prompts_            | Generator prompts; see [Layout selection](#layout-selection-for-corne_mx_pro). **Untested.** |
+| `keebart/corne_mx_pro/standard`   | _prompts_            | Generator prompts; see [Layout selection](#layout-selection-for-corne_mx_pro). **Untested.** |
+
+`keebart/sofle_choc_pro` is **in mainline QMK** and does not need the fork. It is documented in [supported_keyboards.md#sofle](supported_keyboards.md#sofle) with its required `-layout LAYOUT_sofle` override.
+
+## One-time fork setup
+
+### 1. Clone Keebart's fork
+
+```sh
+git clone https://github.com/Keebart/vial-qmk-keebart
+```
+
+### 2. Initialize submodules
+
+Initialize submodules in the clone:
+
+```sh
+cd path/to/vial-qmk-keebart && qmk git-submodule
+```
+
+Equivalent to `git submodule update --init --recursive`. Takes a few minutes.
+
+### 3. Point `qmk config` at the fork
+
+```sh
+qmk config user.qmk_home=/path/to/vial-qmk-keebart
+qmk config user.keyboard=keebart/corne_choc_pro/standard
+```
+
+See [Setting `user.qmk_home`](../README.md#setting-userqmk_home) in the main README for path-expansion caveats.
+
+## Building
+
+Once configured, the generator works identically to mainline:
+
+```sh
+./generator.sh -src ./selenium --copy
+```
+
+For `corne_choc_pro/*`, it detects the single supported layout and proceeds silently. For `corne_mx_pro/*`, it prompts (see [Layout selection](#layout-selection-for-corne_mx_pro)).
+
+Compile and flash:
+
+```sh
+qmk compile -kb keebart/corne_choc_pro/standard -km selenium
+qmk flash   -kb keebart/corne_choc_pro/standard -km selenium
+```
+
+## Build target gotcha: variant suffix is mandatory
+
+`keebart/corne_choc_pro` and `keebart/corne_mx_pro` (without the `/mini` or `/standard` suffix) are **not buildable targets** — they are parent folders. Always include the variant suffix from the [Boards covered](#boards-covered) table.
+
+## Layout selection for `corne_mx_pro`
+
+`corne_mx_pro/mini` and `corne_mx_pro/standard` each expose four layouts. The generator prompts you to pick the one matching your physical board:
+
+| Layout                   | Physical board                                       |
+| ------------------------ | ---------------------------------------------------- |
+| `LAYOUT_split_3x5_3`     | 3×5 grid, 3 thumbs, no inner column                  |
+| `LAYOUT_split_3x5_3_ex2` | 3×5 grid + inner-column daughterboard (4 extra keys) |
+| `LAYOUT_split_3x6_3`     | 3×6 grid, 3 thumbs, no inner column                  |
+| `LAYOUT_split_3x6_3_ex2` | 3×6 grid + inner-column daughterboard (4 extra keys) |
+
+For `_ex2` layouts, the 4 extra keys default to `KC_NO`. Bind them via `ODK_EXT_LT/LB/RT/RB` in your keymap's `options.h` — see [Inner-column extensions](supported_keyboards.md#inner-column-extensions-_ex2-layouts) in `supported_keyboards.md`.
+
+## Switching back to mainline
+
+To return to a mainline QMK keyboard (e.g. `beekeeb/piantor`):
+
+```sh
+qmk config user.qmk_home=/path/to/qmk_firmware
+qmk config user.keyboard=beekeeb/piantor
+```
+
+The generator works identically on mainline.

--- a/docs/supported_keyboards.md
+++ b/docs/supported_keyboards.md
@@ -1,0 +1,106 @@
+# Supported keyboards
+
+The `LAYOUT_*` names below are QMK layout macros — pass one to `generator.sh -layout <LAYOUT>` to skip auto-detection when the board exposes multiple matching layouts.
+
+The following physical layouts are supported:
+
+- `LAYOUT_split_3x5_2`
+- `LAYOUT_split_3x5_3`
+- `LAYOUT_split_3x5_3_ex2` (4 extra inner-column keys — see [Inner-column extensions](#inner-column-extensions-_ex2-layouts))
+- `LAYOUT_split_3x6_3`
+- `LAYOUT_split_3x6_3_ex2` (4 extra inner-column keys — see [Inner-column extensions](#inner-column-extensions-_ex2-layouts))
+- `LAYOUT_ortho_4x10`
+- `LAYOUT_ortho_4x12`
+- `LAYOUT_ortho_5x10`
+- `LAYOUT_ortho_5x12`
+- `LAYOUT_planck_grid`
+- `LAYOUT_keebio_iris`
+- `LAYOUT_keyboardio_atreus` (8 keys beyond the spec — see [Atreus](#atreus))
+- `LAYOUT` on Lily58 (all variants: `rev1`, `light`, `lite_rev3`, `glow_enc`, `r2g` — see [Lily58](#lily58))
+- `LAYOUT` on Sofle (all variants: `sofle/rev1`, `sofle/keyhive`, `sofle_choc`, `sofle_pico`, `splitkb/aurora/sofle_v2`, `mechboards/sofle/pro`, `keebart/sofle_choc_pro` — see [Sofle](#sofle))
+
+If your keyboard is not listed, you can add its layout to `shared/layouts.h` or [open an issue](https://github.com/OneDeadKey/qmk-config-aekeynox/issues) for help.
+
+## Lily58
+
+58 keys, 5 rows + 4 thumbs per side.
+
+Lily58 has **4 keys beyond** the 42-key Selenium/Arsenik spec: 1 inner-corner key per side (below the home row) and 1 extra outermost thumb per side.
+They default to `KC_NO` (inert). Override in your keymap's `options.h`:
+
+```c
+#define ODK_EXT_INNER_L     KC_LBRC  // left  inner corner
+#define ODK_EXT_INNER_R     KC_RBRC  // right inner corner
+#define ODK_EXT_THUMB_OUT_L KC_LCTL  // left  outermost thumb
+#define ODK_EXT_THUMB_OUT_R KC_RCTL  // right outermost thumb
+```
+
+**Selenium caveat:** Selenium is a 42-key spec, so logical row 1 (the top row) is transparent on every layer.
+On Lily58 with Selenium, the physical number row emits nothing until you edit `selenium/keymap.c` row 1 locally.
+**Arsenik is unaffected** — its base layer uses the top row for numbers natively.
+
+## Sofle
+
+60 keys, Lily58 + 1 extra outermost thumb per side.
+
+Sofle adds **2 more keys** to the Lily58 layout — an extra outermost thumb per side (matrix `[4,0]` left, `[9,0]` right).
+On most Sofle builds, that position is a rotary encoder press.
+
+Everything from the [Lily58](#lily58) section applies, plus two more override slots:
+
+```c
+#define ODK_EXT_THUMB_FAR_L KC_MUTE  // left  outermost thumb (encoder press)
+#define ODK_EXT_THUMB_FAR_R KC_MPLY  // right outermost thumb (encoder press)
+```
+
+The same Selenium top-row caveat applies.
+
+**`keebart/sofle_choc_pro` needs a manual override.** Unlike other Sofle variants, this board reports its layout to QMK as `LAYOUT_split_4x6_5` — a generic community-shared name that means a different physical layout on non-Sofle boards. The generator refuses to auto-bind it to avoid producing wrong keymaps elsewhere. Pass `-layout LAYOUT_sofle` to force the Sofle layout:
+
+```bash
+./generator.sh -src ./arsenik -kb keebart/sofle_choc_pro -layout LAYOUT_sofle --copy
+```
+
+## Inner-column extensions (`_ex2` layouts)
+
+Boards that expose an `_ex2` variant have **4 extra physical keys** — 2 per side, stacked as a short inner column on the top and middle rows.
+These keys are outside the Selenium/Arsenik spec, so they default to `KC_NO` (inert).
+
+Known boards:
+
+- [Corne v4](https://github.com/foostan/crkbd) — `LAYOUT_split_3x6_3_ex2`
+- [cornifi](https://github.com/v3lmx/cornifi) — `LAYOUT_split_3x5_3_ex2`
+
+To bind the extra keys, add to your keymap's `options.h` before generating:
+
+```c
+#define ODK_EXT_LT KC_TAB   // left  inner-top
+#define ODK_EXT_LB KC_LCTL  // left  inner-middle
+#define ODK_EXT_RT KC_BSPC  // right inner-top
+#define ODK_EXT_RB KC_RSFT  // right inner-middle
+```
+
+The bound keycode is the same across all layers.
+
+## Atreus
+
+44 keys (Keyboard.io Atreus), exposed by QMK as `LAYOUT_keyboardio_atreus`.
+
+Atreus has **8 keys beyond** the 42-key Selenium/Arsenik spec: 1 inner-corner key per side (between the home block and the thumb cluster) and 3 extra thumb keys per side.
+They default to `KC_NO` (inert). Override in your keymap's `options.h`:
+
+```c
+#define ODK_EXT_INNER_L         KC_LBRC  // left  inner corner
+#define ODK_EXT_INNER_R         KC_RBRC  // right inner corner
+#define ODK_EXT_THUMB_OUT_L     KC_LCTL  // left  outer thumb
+#define ODK_EXT_THUMB_OUT_R     KC_RCTL  // right outer thumb
+#define ODK_EXT_THUMB_FAR_L     KC_LALT  // left  far thumb
+#define ODK_EXT_THUMB_FAR_R     KC_RALT  // right far thumb
+#define ODK_EXT_THUMB_FAR_EXT_L KC_LGUI  // left  outermost thumb
+#define ODK_EXT_THUMB_FAR_EXT_R KC_RGUI  // right outermost thumb
+```
+
+`ODK_EXT_INNER_*`, `ODK_EXT_THUMB_OUT_*` and `ODK_EXT_THUMB_FAR_*` are shared with [Lily58](#lily58) / [Sofle](#sofle).
+`ODK_EXT_THUMB_FAR_EXT_L` and `ODK_EXT_THUMB_FAR_EXT_R` are Atreus-only.
+
+The same Selenium top-row caveat applies.

--- a/generator.sh
+++ b/generator.sh
@@ -24,11 +24,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Print usage and exit
 usage() {
-    echo "Usage: $0 -src <keymap_folder> [-kb <keyboard_model>] [-km <ref_keymap>] [-layout <LAYOUT>] [-name <target_name>] [--copy|-cp]"
+    echo "Usage: $0 -src <keymap_folder> [-kb <keyboard_model>] [-layout <LAYOUT>] [-name <target_name>] [--copy|-cp]"
     echo "  -src <keymap_folder>   Path to the keymap source folder (required)"
-    echo "  -kb <keyboard_model>   Specify the keyboard model (optional, will use qmk config if not provided)"
-    echo "  -km <ref_keymap>       Reference keymap for layout detection (optional, will use qmk config if not provided)"
-    echo "  -layout <LAYOUT>       Explicit LAYOUT macro (e.g. LAYOUT_split_3x6_3_ex2); skips auto-detection from -km"
+    echo "  -kb <keyboard_model>   Keyboard model (optional, falls back to qmk config user.keyboard)"
+    echo "  -layout <LAYOUT>       Explicit LAYOUT macro override (e.g. LAYOUT_split_3x6_3_ex2)"
     echo "  -name <target_name>    Name for the generated keymap (default: source folder name)"
     echo "  --copy, -cp            Copy output to \$QMK_HOME/keyboards/<keyboard_model>/keymaps/<target_name>"
     exit 1
@@ -37,7 +36,6 @@ usage() {
 # Parse arguments
 copy_keymap=false
 keyboard_model=""
-keymap=""
 layout_override=""
 src_path=""
 target_name=""
@@ -51,10 +49,6 @@ while [ "$#" -gt 0 ]; do
     -kb)
         shift
         keyboard_model="$1"
-        ;;
-    -km)
-        shift
-        keymap="$1"
         ;;
     -layout)
         shift
@@ -90,8 +84,8 @@ if [ -z "$target_name" ]; then
     target_name="$(basename "$(cd "$src_path" && pwd)")"
 fi
 
-if [ -z "$keyboard_model" ] || { [ -z "$keymap" ] && [ -z "$layout_override" ]; }; then
-    log_info "Requirements: It is recommended to have set QMK user.keyboard, user.keymap, and user.qmk_home using 'qmk config'."
+if [ -z "$keyboard_model" ]; then
+    log_info "Requirements: it is recommended to have set QMK user.keyboard and user.qmk_home using 'qmk config'."
     log_info "See https://docs.qmk.fm/cli_configuration#setting-user-defaults for more information."
     log_info "Your current configuration:"
     qmk config || true
@@ -108,11 +102,6 @@ if [ -z "$keyboard_model" ]; then
     keyboard_model=$(qmk_config_value user.keyboard)
     log_info "No keyboard_model provided with '-kb' argument, using value from qmk config: ${CYAN}$keyboard_model${NC}"
 fi
-# -km is only needed when the layout must be auto-detected from a reference keymap
-if [ -z "$keymap" ] && [ -z "$layout_override" ]; then
-    keymap=$(qmk_config_value user.keymap)
-    log_info "No keymap provided with '-km' argument, using value from qmk config: ${CYAN}$keymap${NC}"
-fi
 
 # Set QMK_HOME if not already set
 if [ -z "${QMK_HOME+x}" ]; then
@@ -122,63 +111,139 @@ if [ -z "${QMK_HOME+x}" ]; then
     QMK_HOME="${QMK_HOME/#\~/$HOME}"
 fi
 
-# Find the keymaps folder for a given keyboard name
-get_keymaps_folder() {
-    local keyboard_model="$1"
-    local keymap="$2"
-    while [ ! -d "$QMK_HOME/keyboards/$keyboard_model/keymaps/$keymap" ]; do
-        if [ "$keyboard_model" = "." ]; then
-            echo "Couldn't find keymap folder for your keyboard/keymap" >&2
-            exit 1
-        fi
-        keyboard_model=$(dirname "$keyboard_model")
-    done
-    echo "$QMK_HOME/keyboards/$keyboard_model/keymaps/$keymap"
+# Validate QMK_HOME early if we're going to copy
+if [ "$copy_keymap" = true ] && { [ -z "$QMK_HOME" ] || [ ! -d "$QMK_HOME" ]; }; then
+    log_error "QMK_HOME is empty or not a directory: '${QMK_HOME}'"
+    log_info "Set it via 'qmk config user.qmk_home=<path>' or the QMK_HOME env var."
+    exit 1
+fi
+
+# Normalize a `-layout arbitrary_name` entered by the user into the ONEDEADKEY_LAYOUT_* form.
+# Accepts bare ("split_3x6_3"), LAYOUT_* and ONEDEADKEY_LAYOUT_* inputs.
+normalize_layout() {
+    local layout="$1"
+    if [[ "$layout" == ONEDEADKEY_LAYOUT_* ]]; then
+        echo "$layout"
+    elif [[ "$layout" == LAYOUT_* ]]; then
+        echo "ONEDEADKEY_$layout"
+    else
+        echo "ONEDEADKEY_LAYOUT_$layout"
+    fi
 }
 
-# Detect layout name
-# If $3 (override) is provided, skip auto-detection from the reference keymap.
-detect_layout_name() {
+# List ONEDEADKEY_LAYOUT_* layouts supported by shared/layouts.h.
+# Declarations use either `defined FOO` or `defined(FOO)` (parenthesised form
+# appears inside OR-guards for keyboard families like Lily58 / Sofle).
+get_supported_layouts() {
+    grep -oE 'defined[[:space:](]+ONEDEADKEY_LAYOUT_[A-Za-z0-9_]+' "$SCRIPT_DIR/shared/layouts.h" \
+        | sed -E 's/defined[[:space:](]+//' \
+        | sort -u
+}
+
+# Resolve the ONEDEADKEY_LAYOUT_* name to target for $keyboard_model.
+# Source of truth: QMK's own keyboard metadata (`qmk info -f json`) — the
+# `layouts` field declares every physical layout the board exposes. We
+# intersect that set with layouts supported by shared/layouts.h.
+detect_onedeadkey_layout_name() {
     local keyboard_model="$1"
-    local keymap="$2"
-    local override="${3:-}"
+    local override="${2:-}"
 
-    local layout=""
     if [ -n "$override" ]; then
-        # Accept bare (split_3x6_3_ex2), LAYOUT_* or ONEDEADKEY_LAYOUT_* forms
-        layout="$override"
-    else
-        local keymap_folder
-        keymap_folder=$(get_keymaps_folder "$keyboard_model" "$keymap")
-
-        if [ -f "$keymap_folder/keymap.c" ]; then
-            layout=$(sed -n 's/.*= *\([A-Za-z_][A-Za-z0-9_]*\)(.*/\1/p' "$keymap_folder/keymap.c" | head -n 1)
-        elif [ -f "$keymap_folder/keymap.json" ]; then
-            layout=$(sed -n 's/.*"layout": *"\([^"]*\)".*/\1/p' "$keymap_folder/keymap.json" | head -n 1)
+        local layout supported
+        layout=$(normalize_layout "$override")
+        supported=$(get_supported_layouts)
+        if ! echo "$supported" | grep -qx "$layout"; then
+            log_error "Layout '$layout' is not supported by shared/layouts.h."
+            log_info "  Supported layouts: $(echo "$supported" | tr '\n' ' ')"
+            log_info "  Add it to shared/layouts.h, or pass a supported name."
+            return 1
         fi
+        echo "$layout"
+        return
+    fi
 
-        if [ "$layout" = "LAYOUT" ]; then
-            layout+="_$(echo "$keyboard_model" | sed 's,/,_,g' | sed 's/_rev[0-9]*$//')"
+    if ! command -v jq >/dev/null 2>&1; then
+        log_error "jq is required for layout detection but was not found in PATH."
+        log_info "Install jq, or pass '-layout <LAYOUT_NAME>' to skip auto-detection."
+        return 1
+    fi
+
+    local kb_layouts
+    kb_layouts=$(qmk info -kb "$keyboard_model" -km default -f json 2>/dev/null \
+        | jq -r '.layouts | to_entries[] | [.key, (.value.layout | length)] | @tsv')
+
+    if [ -z "$kb_layouts" ]; then
+        log_error "Could not read layouts for '$keyboard_model' from 'qmk info'."
+        return 1
+    fi
+
+    # Translate each QMK layout name to a candidate ONEDEADKEY_LAYOUT_* and
+    # keep only those supported by shared/layouts.h.
+    # A bare "LAYOUT" macro (used by some single-layout boards) maps to the
+    # keyboard's slug, e.g. lily58/rev1 -> ONEDEADKEY_LAYOUT_lily58.
+    local slug
+    slug=$(echo "$keyboard_model" | sed 's,/,_,g' | sed 's/_rev[0-9]*$//')
+    local supported
+    supported=$(get_supported_layouts)
+
+    local candidates=""
+    while IFS=$'\t' read -r kb_layout key_count; do
+        [ -z "$kb_layout" ] && continue
+        local candidate
+        if [ "$kb_layout" = "LAYOUT" ]; then
+            candidate="ONEDEADKEY_LAYOUT_$slug"
+        else
+            candidate="ONEDEADKEY_${kb_layout}"
         fi
+        if echo "$supported" | grep -qx "$candidate"; then
+            candidates+="$candidate"$'\t'"$key_count"$'\n'
+        fi
+    done <<< "$kb_layouts"
+
+    candidates="${candidates%$'\n'}"
+    local n_candidates=0
+    [ -n "$candidates" ] && n_candidates=$(echo "$candidates" | wc -l)
+
+    if [ "$n_candidates" -eq 0 ]; then
+        log_error "No supported layout matches what '$keyboard_model' exposes."
+        log_info "  Keyboard exposes: $(echo "$kb_layouts" | cut -f1 | tr '\n' ' ')"
+        log_info "  Add a matching ONEDEADKEY_LAYOUT_* to shared/layouts.h, or override with '-layout <name>'."
+        return 1
     fi
 
-    # Normalize: ensure the ONEDEADKEY_LAYOUT_ prefix
-    if [[ "$layout" == ONEDEADKEY_LAYOUT_* ]]; then
-        :
-    elif [[ "$layout" == LAYOUT_* ]]; then
-        layout="ONEDEADKEY_$layout"
-    else
-        layout="ONEDEADKEY_LAYOUT_$layout"
+    if [ "$n_candidates" -eq 1 ]; then
+        echo "$candidates" | cut -f1
+        return
     fi
 
-    # Warn (don't fail) if the resolved layout has no matching branch in shared/layouts.h.
-    # Branches may use either `#elif defined FOO` (space) or `#elif defined(FOO)` (paren, for OR-guards).
-    # Compilation would later fail at the '#error "Arsenik: Unknown layout"' fallthrough.
-    if ! grep -Eq "defined[[:space:](]+$layout\b" "$SCRIPT_DIR/shared/layouts.h" 2>/dev/null; then
-        log_warn "Layout ${CYAN}$layout${NC} has no branch in shared/layouts.h — compile will fail unless you add one."
+    # Multiple supported candidates. Sort once by key count desc, then
+    # reverse-alpha for stable tiebreak ("_ex2" wins over its base).
+    local sorted
+    sorted=$(echo "$candidates" | sort -t$'\t' -k2,2 -nr -k1,1 -r)
+
+    if [ ! -t 0 ]; then
+        # Non-interactive (piped / scripted) — the prompt is for humans only.
+        # Refuse to guess; require an explicit -layout.
+        log_error "Keyboard '$keyboard_model' has multiple supported layouts; pass '-layout' explicitly."
+        log_info "  Candidates: $(echo "$sorted" | cut -f1 | tr '\n' ' ')"
+        return 1
     fi
 
-    echo "$layout"
+    log_info "Multiple supported layouts available for '$keyboard_model':"
+    local i=1
+    while IFS=$'\t' read -r name keys; do
+        echo "  $i) $name ($keys keys)" >&2
+        i=$((i + 1))
+    done <<< "$sorted"
+    local choice picked
+    read -p "Choose [1-$n_candidates, default=1]: " choice
+    choice="${choice:-1}"
+    picked=$(echo "$sorted" | sed -n "${choice}p" | cut -f1)
+    if [ -z "$picked" ]; then
+        log_error "Invalid choice: '$choice'."
+        return 1
+    fi
+    echo "$picked"
 }
 
 create_output_dir() {
@@ -197,14 +262,15 @@ create_output_dir() {
     mkdir -p "$output_dir"
 }
 
-# Generate the keymap
 generate_keymap() {
     local keyboard_model="$1"
-    local keymap="$2"
-    local output_dir="$3"
-    local src="$4"
+    local output_dir="$2"
+    local src="$3"
 
-    local layout_name="$(detect_layout_name "$keyboard_model" "$keymap" "$layout_override")"
+    local layout_name
+    if ! layout_name=$(detect_onedeadkey_layout_name "$keyboard_model" "$layout_override"); then
+        exit 1
+    fi
     if [ -n "$layout_override" ]; then
         log_info "Using explicit layout (from -layout): ${CYAN}$layout_name${NC}"
     else
@@ -236,7 +302,7 @@ generate_keymap() {
 output_dir="./output/$keyboard_model/keymaps/$target_name"
 
 create_output_dir "$output_dir"
-generate_keymap "$keyboard_model" "$keymap" "$output_dir" "$src_path"
+generate_keymap "$keyboard_model" "$output_dir" "$src_path"
 
 if [ "$copy_keymap" = true ]; then
     dest_dir="$QMK_HOME/keyboards/$keyboard_model/keymaps/$target_name"
@@ -255,7 +321,6 @@ if [ "$copy_keymap" = true ]; then
     cp -R "$output_dir/." "$dest_dir/"
     log_success "Copied keymap to ${CYAN}$dest_dir${NC}"
     log_info "Finally, you may want to :"
-    log_info "    cd $dest_dir"
     log_info "    qmk compile -kb $keyboard_model -km $target_name    # compile the keymap"
     log_info "    # connect the keyboard"
     log_info "    qmk flash -kb $keyboard_model -km $target_name      # flash the keyboard"

--- a/generator.sh
+++ b/generator.sh
@@ -320,7 +320,7 @@ if [ "$copy_keymap" = true ]; then
     mkdir -p "$dest_dir"
     cp -R "$output_dir/." "$dest_dir/"
     log_success "Copied keymap to ${CYAN}$dest_dir${NC}"
-    log_info "Finally, you may want to :"
+    log_info "Finally, you may want to:"
     log_info "    qmk compile -kb $keyboard_model -km $target_name    # compile the keymap"
     log_info "    # connect the keyboard"
     log_info "    qmk flash -kb $keyboard_model -km $target_name      # flash the keyboard"

--- a/shared/layouts.h
+++ b/shared/layouts.h
@@ -385,5 +385,5 @@
     )
 
 #else
-#    error "Arsenik: Unknown layout"
+#    error "Your keyboard appears unsupported — open an issue on GitHub to propose an implementation or ask the team for support."
 #endif

--- a/tests/README.md
+++ b/tests/README.md
@@ -28,6 +28,10 @@ bash tests/test_exhaustive.sh -target selenium
 
 # Override keyboard and parallel jobs
 bash tests/test_per_option.sh -kb beekeeb/piantor -j 4
+
+# Multi-layout boards require -layout (the generator refuses to guess in
+# non-interactive contexts)
+bash tests/test_per_option.sh -kb crkbd/rev1 -layout LAYOUT_split_3x6_3
 ```
 
 ## Running tests in Docker

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -4,7 +4,7 @@
 # Source this file from test scripts.
 
 TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-QMK_DIR="$(cd "$TESTS_DIR/.." && pwd)"
+REPO_DIR="$(cd "$TESTS_DIR/.." && pwd)"
 
 # Colors
 RED='\033[0;31m'
@@ -73,13 +73,13 @@ _generate_and_install() {
     local sed_exprs=("$@")
 
     KEYMAP_NAME="test_${target}"
-    local gen_dir="$QMK_DIR/output/$KEYBOARD/keymaps/$target"
-    local output_dir="$QMK_DIR/output/$KEYBOARD/keymaps/$KEYMAP_NAME"
+    local gen_dir="$REPO_DIR/output/$KEYBOARD/keymaps/$target"
+    local output_dir="$REPO_DIR/output/$KEYBOARD/keymaps/$KEYMAP_NAME"
     local dest_dir="$QMK_HOME/keyboards/$KEYBOARD/keymaps/$KEYMAP_NAME"
 
-    # Generate (generator outputs relative to cwd, so run from QMK_DIR)
+    # Generate (generator outputs relative to cwd, so run from REPO_DIR)
     rm -rf "$output_dir" "$gen_dir"
-    (cd "$QMK_DIR" && bash generator.sh -src "./$target" -kb "$KEYBOARD" > /dev/null 2>&1)
+    (cd "$REPO_DIR" && bash generator.sh -src "./$target" -kb "$KEYBOARD" > /dev/null 2>&1)
     mv "$gen_dir" "$output_dir"
 
     # Patch options.h
@@ -96,7 +96,7 @@ _generate_and_install() {
 # Cleanup generated and installed files
 _cleanup() {
     local target="$1"
-    local output_dir="$QMK_DIR/output/$KEYBOARD/keymaps/test_${target}"
+    local output_dir="$REPO_DIR/output/$KEYBOARD/keymaps/test_${target}"
     local dest_dir="$QMK_HOME/keyboards/$KEYBOARD/keymaps/test_${target}"
     rm -rf "$dest_dir" "$output_dir"
 }

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -77,9 +77,13 @@ _generate_and_install() {
     local output_dir="$REPO_DIR/output/$KEYBOARD/keymaps/$KEYMAP_NAME"
     local dest_dir="$QMK_HOME/keyboards/$KEYBOARD/keymaps/$KEYMAP_NAME"
 
-    # Generate (generator outputs relative to cwd, so run from REPO_DIR)
+    # Generate (generator outputs relative to cwd, so run from REPO_DIR).
+    # Forward -layout when set — required for multi-layout boards in non-
+    # interactive mode (the generator refuses to guess without a TTY).
+    local layout_arg=()
+    [ -n "${LAYOUT_OVERRIDE:-}" ] && layout_arg=(-layout "$LAYOUT_OVERRIDE")
     rm -rf "$output_dir" "$gen_dir"
-    (cd "$REPO_DIR" && bash generator.sh -src "./$target" -kb "$KEYBOARD" > /dev/null 2>&1)
+    (cd "$REPO_DIR" && bash generator.sh -src "./$target" -kb "$KEYBOARD" "${layout_arg[@]}" > /dev/null 2>&1)
     mv "$gen_dir" "$output_dir"
 
     # Patch options.h

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -3,7 +3,10 @@
 # Run all compile tests: per-option → exhaustive
 #
 # Usage:
-#   ./run_all.sh [-kb <keyboard>] [-target <target>] [-j <jobs>]
+#   ./run_all.sh [-kb <keyboard>] [-target <target>] [-layout <LAYOUT>] [-j <jobs>]
+#
+# -layout is required for multi-layout boards (e.g. crkbd/rev1, beekeeb/piantor)
+# because the generator refuses to guess in non-interactive contexts.
 
 set -euo pipefail
 

--- a/tests/test_exhaustive.sh
+++ b/tests/test_exhaustive.sh
@@ -4,7 +4,9 @@
 # Tests every valid combination of config options.
 #
 # Usage:
-#   ./test_exhaustive.sh [-kb <keyboard>] [-target <target>] [-j <jobs>]
+#   ./test_exhaustive.sh [-kb <keyboard>] [-target <target>] [-layout <LAYOUT>] [-j <jobs>]
+#
+# -layout is required for multi-layout boards (e.g. crkbd/rev1, beekeeb/piantor).
 
 set -euo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
@@ -14,8 +16,9 @@ while [ "$#" -gt 0 ]; do
     case "$1" in
         -kb)     shift; KEYBOARD="$1" ;;
         -target) shift; TARGET="$1" ;;
+        -layout) shift; LAYOUT_OVERRIDE="$1" ;;
         -j)      shift; JOBS="$1" ;;
-        *)       echo "Usage: $0 [-kb <keyboard>] [-target arsenik|selenium] [-j <jobs>]"; exit 1 ;;
+        *)       echo "Usage: $0 [-kb <keyboard>] [-target arsenik|selenium] [-layout <LAYOUT>] [-j <jobs>]"; exit 1 ;;
     esac
     shift
 done

--- a/tests/test_layout_flag.sh
+++ b/tests/test_layout_flag.sh
@@ -29,7 +29,7 @@ setup_env
 log_section "generator.sh — -layout flag"
 
 TARGET="selenium"
-OUTPUT_DIR="$QMK_DIR/output/$KEYBOARD/keymaps/$TARGET"
+OUTPUT_DIR="$REPO_DIR/output/$KEYBOARD/keymaps/$TARGET"
 EXPECTED_DEFINE="#define ONEDEADKEY_LAYOUT_split_3x6_3"
 
 # Run the generator with a -layout argument and assert the generated
@@ -41,7 +41,7 @@ _run_layout_test() {
     local expected="${3:-$EXPECTED_DEFINE}"
 
     rm -rf "$OUTPUT_DIR"
-    if ! (cd "$QMK_DIR" && bash generator.sh -src "./$TARGET" -kb "$KEYBOARD" -layout "$layout_arg" > /dev/null 2>&1); then
+    if ! (cd "$REPO_DIR" && bash generator.sh -src "./$TARGET" -kb "$KEYBOARD" -layout "$layout_arg" > /dev/null 2>&1); then
         log_fail "$name (generator exited non-zero)"
         return
     fi
@@ -60,7 +60,7 @@ _run_layout_test "full prefix (ONEDEADKEY_LAYOUT_split_3x6_3)" "ONEDEADKEY_LAYOU
 # Unknown-layout path: generator must emit a WARN to stdout/stderr but still succeed.
 # (Compile would later fail at the '#error' fallthrough in shared/layouts.h.)
 rm -rf "$OUTPUT_DIR"
-warn_output=$(cd "$QMK_DIR" && bash generator.sh -src "./$TARGET" -kb "$KEYBOARD" -layout "LAYOUT_does_not_exist" 2>&1)
+warn_output=$(cd "$REPO_DIR" && bash generator.sh -src "./$TARGET" -kb "$KEYBOARD" -layout "LAYOUT_does_not_exist" 2>&1)
 if echo "$warn_output" | grep -q "has no branch in shared/layouts.h"; then
     log_pass "unknown layout emits warning"
 else
@@ -70,7 +70,7 @@ fi
 # -layout should work without -km and without qmk config user.keymap.
 # Clear QMK_CONFIG's user.keymap in a subshell-safe way by pointing HOME elsewhere.
 rm -rf "$OUTPUT_DIR"
-if (cd "$QMK_DIR" && bash generator.sh -src "./$TARGET" -kb "$KEYBOARD" -layout "LAYOUT_split_3x6_3" > /dev/null 2>&1); then
+if (cd "$REPO_DIR" && bash generator.sh -src "./$TARGET" -kb "$KEYBOARD" -layout "LAYOUT_split_3x6_3" > /dev/null 2>&1); then
     if grep -qF "$EXPECTED_DEFINE" "$OUTPUT_DIR/config.h" 2>/dev/null; then
         log_pass "-layout works without -km"
     else

--- a/tests/test_layout_flag.sh
+++ b/tests/test_layout_flag.sh
@@ -13,11 +13,13 @@ TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$TESTS_DIR/common.sh"
 
 # CLI — accept the superset of flags used across the test suite so run_all.sh
-# can forward "$@" uniformly. -target and -j are irrelevant here and ignored.
+# can forward "$@" uniformly. -target, -layout and -j are irrelevant here
+# (each test below passes its own -layout explicitly) and ignored.
 while [ "$#" -gt 0 ]; do
     case "$1" in
         -kb)     shift; KEYBOARD="$1" ;;
         -target) shift ;;  # accepted for parity, unused
+        -layout) shift ;;  # accepted for parity, unused
         -j)      shift ;;  # accepted for parity, unused
         *)       echo "Usage: $0 [-kb <keyboard>]"; exit 1 ;;
     esac
@@ -57,27 +59,19 @@ _run_layout_test "bare form (split_3x6_3)"                    "split_3x6_3"
 _run_layout_test "LAYOUT_ prefix (LAYOUT_split_3x6_3)"        "LAYOUT_split_3x6_3"
 _run_layout_test "full prefix (ONEDEADKEY_LAYOUT_split_3x6_3)" "ONEDEADKEY_LAYOUT_split_3x6_3"
 
-# Unknown-layout path: generator must emit a WARN to stdout/stderr but still succeed.
-# (Compile would later fail at the '#error' fallthrough in shared/layouts.h.)
+# Unknown-layout path: generator must fail-fast (exit non-zero) with a clear
+# error message and must not produce config.h.
 rm -rf "$OUTPUT_DIR"
-warn_output=$(cd "$REPO_DIR" && bash generator.sh -src "./$TARGET" -kb "$KEYBOARD" -layout "LAYOUT_does_not_exist" 2>&1)
-if echo "$warn_output" | grep -q "has no branch in shared/layouts.h"; then
-    log_pass "unknown layout emits warning"
+err_output=$(cd "$REPO_DIR" && bash generator.sh -src "./$TARGET" -kb "$KEYBOARD" -layout "LAYOUT_does_not_exist" 2>&1)
+err_status=$?
+if [ "$err_status" -eq 0 ]; then
+    log_fail "unknown layout fails fast (generator exited 0, expected non-zero)"
+elif ! echo "$err_output" | grep -q "is not supported by shared/layouts.h"; then
+    log_fail "unknown layout fails fast (expected 'is not supported' in error output)"
+elif [ -f "$OUTPUT_DIR/config.h" ]; then
+    log_fail "unknown layout fails fast (config.h was written despite the error)"
 else
-    log_fail "unknown layout emits warning (expected WARN in output)"
-fi
-
-# -layout should work without -km and without qmk config user.keymap.
-# Clear QMK_CONFIG's user.keymap in a subshell-safe way by pointing HOME elsewhere.
-rm -rf "$OUTPUT_DIR"
-if (cd "$REPO_DIR" && bash generator.sh -src "./$TARGET" -kb "$KEYBOARD" -layout "LAYOUT_split_3x6_3" > /dev/null 2>&1); then
-    if grep -qF "$EXPECTED_DEFINE" "$OUTPUT_DIR/config.h" 2>/dev/null; then
-        log_pass "-layout works without -km"
-    else
-        log_fail "-layout works without -km (expected define missing)"
-    fi
-else
-    log_fail "-layout works without -km (generator exited non-zero)"
+    log_pass "unknown layout fails fast"
 fi
 
 rm -rf "$OUTPUT_DIR"

--- a/tests/test_per_option.sh
+++ b/tests/test_per_option.sh
@@ -4,7 +4,9 @@
 # Toggles one option at a time to verify each compiles independently.
 #
 # Usage:
-#   ./test_per_option.sh [-kb <keyboard>] [-target <target>] [-j <jobs>]
+#   ./test_per_option.sh [-kb <keyboard>] [-target <target>] [-layout <LAYOUT>] [-j <jobs>]
+#
+# -layout is required for multi-layout boards (e.g. crkbd/rev1, beekeeb/piantor).
 
 set -euo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
@@ -14,8 +16,9 @@ while [ "$#" -gt 0 ]; do
     case "$1" in
         -kb)     shift; KEYBOARD="$1" ;;
         -target) shift; TARGET="$1" ;;
+        -layout) shift; LAYOUT_OVERRIDE="$1" ;;
         -j)      shift; JOBS="$1" ;;
-        *)       echo "Usage: $0 [-kb <keyboard>] [-target arsenik|selenium] [-j <jobs>]"; exit 1 ;;
+        *)       echo "Usage: $0 [-kb <keyboard>] [-target arsenik|selenium] [-layout <LAYOUT>] [-j <jobs>]"; exit 1 ;;
     esac
     shift
 done


### PR DESCRIPTION
Previously layout detection inspected QMK_HOME subfolders with a regex over keyboard sources — fragile and forcing QMK_HOME to be populated even for generate-only runs. `qmk info` is QMK's own declaration of which layouts a board exposes; intersecting it with shared/layouts.h gives an authoritative match and lets the generator work without a populated QMK_HOME (until `--copy` is used).

BREAKING CHANGE:
- Layout detection now relies on `qmk info` instead of inspecting QMK_HOME subfolders.
- `jq` is required.