### PR TITLE
fix(selenium): tapping term for right pinky

### DIFF
--- a/selenium/IMPLEMENTATION.md
+++ b/selenium/IMPLEMENTATION.md
@@ -41,7 +41,7 @@ QMK natively provides one global `TAPPING_TERM` plus optional per-key callback f
 
 The split is driven by `tap_keycode_is_tap_preferred()` (Selenium QMK helper), which returns `true` for keycodes that correspond to Selenium ZMK's `&hrm`/`&lt` behaviors:
 
-- Letters, numbers, `KC_NO`, `KC_SPACE` — text-producing keys on base layer HRMs and Space thumb
+- Letters, numbers, `KC_NO`, `KC_SPACE`, punctuation — text-producing keys on base layer HRMs and Space thumb
 - `KC_MPLY`, `KC_MUTE`, `KC_PSCR` — media/system keys used as HRM taps on the function layer (Selenium ZMK uses `&hrm` for these)
 
 The result:

--- a/selenium/keymap.c
+++ b/selenium/keymap.c
@@ -229,10 +229,10 @@ static inline bool tap_keycode_is_tap_preferred(uint16_t keycode) {
     // Remove "quantum" part of the keycode to get the action on tap.
     const uint16_t tap_keycode = keycode & 0xff;
 
-    // Letters, numbers, KC_NO, Space — text-producing keys on base layer HRMs
+    // Letters, numbers, KC_NO, Space, punctuation — text-producing keys on base layer HRMs
     // and Space thumb. KC_NO is included because it is used as a placeholder
     // for complex tap actions.
-    if (tap_keycode <= KC_0 || tap_keycode == KC_SPACE) return true;
+    if (tap_keycode <= KC_0 || (tap_keycode >= KC_SPACE && tap_keycode <= KC_SLASH)) return true;
 
     // Media/system keys used as HRM taps on the function layer.
     // ZMK uses &hrm (tap-preferred, 300ms) for these positions.


### PR DESCRIPTION
With `HRM_SHIFT` enabled, the right pinky becomes a tap/hold key but its keycode (`KC_SEMICOLON`) was not part of the range for the long, "tap-prefered" `TAPPING_TERM`. Also include other similar punctuation in case someone tweaks their keymap to include one of these.