### PR TITLE
fix(selenium): pin the right mod through the whole mod-hold nav hold

### DIFF
--- a/selenium/keymap.c
+++ b/selenium/keymap.c
@@ -142,25 +142,16 @@ static void vim_next_action(void) {
 }
 
 #ifdef ENABLE_MOD_HOLD_NAVIGATION
-// The left-thumb LT keycode depends on LEFT_HAND_SPACE; the right thumb always
-// resolves to a different keycode (either via a different tap code or a
-// different target layer), so matching on the left-thumb keycode is unambiguous.
-#    ifdef LEFT_HAND_SPACE
-#        define MHN_LEFT_LT LT(_SE_NAV, KC_SPC)
+// Mods pinned for the lifetime of the nav-layer thumb hold (0 = inactive).
+// These match VIM_PREV / VIM_NEXT's mod-morph trigger, which fires on LAlt or
+// LGUI: pin LGUI on Mac, LAlt elsewhere, so pinning actually engages the morph.
+#    ifdef MAC_MODIFIERS
+#        define MHN_MODS_TO_PIN (MOD_BIT(KC_LGUI))
 #    else
-#        define MHN_LEFT_LT LT(_SE_NAV, KC_BSPC)
+#        define MHN_MODS_TO_PIN (MOD_BIT(KC_LALT))
 #    endif
 
-static bool mhn_left_thumb_pressed = false;
-static bool mhn_alt_held = false;
-
-layer_state_t layer_state_set_user(layer_state_t state) {
-    if (mhn_left_thumb_pressed && !mhn_alt_held && IS_LAYER_ON_STATE(state, _SE_NAV)) {
-        register_mods(MOD_BIT(KC_LALT));
-        mhn_alt_held = true;
-    }
-    return state;
-}
+static uint8_t mhn_pinned_mods = 0;
 #endif
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
@@ -168,6 +159,18 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         // Track whether another key was pressed while LSK_RALT is held
         if (lsk_ralt_held && keycode != LSK_RALT) { lsk_ralt_used = true; }
     }
+
+#ifdef ENABLE_MOD_HOLD_NAVIGATION
+    if (keycode == LTHUMB_HOME) {
+        if (record->event.pressed) {
+            // Pin whichever target mods are held at the instant the thumb goes down.
+            mhn_pinned_mods = get_mods() & MHN_MODS_TO_PIN;
+        } else if (mhn_pinned_mods) {
+            unregister_mods(mhn_pinned_mods);
+            mhn_pinned_mods = 0;
+        }
+    }
+#endif
 
     // NOTE: Insecable space (Shift+Space for Ergol) is NOT implemented.
     // The base layer space uses LT(_nav_num, KC_SPC), which shares the same
@@ -190,9 +193,6 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
                 lsk_ralt_held = true;
                 lsk_ralt_used = false;
                 return false;
-#ifdef ENABLE_MOD_HOLD_NAVIGATION
-            case MHN_LEFT_LT: mhn_left_thumb_pressed = true; return true;
-#endif
         }
     } else {
         switch (keycode) {
@@ -201,20 +201,21 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
                 if (!lsk_ralt_used) { set_oneshot_mods(MOD_BIT(KC_RALT)); }
                 lsk_ralt_held = false;
                 return false;
-#ifdef ENABLE_MOD_HOLD_NAVIGATION
-            case MHN_LEFT_LT:
-                mhn_left_thumb_pressed = false;
-                if (mhn_alt_held) {
-                    unregister_mods(MOD_BIT(KC_LALT));
-                    mhn_alt_held = false;
-                }
-                return true;
-#endif
         }
     }
 
     return true;
 }
+
+#ifdef ENABLE_MOD_HOLD_NAVIGATION
+// Runs after QMK's default processing: re-assert the pinned mods so any
+// HRM/mod-tap release during the thumb hold can't clear them before the next
+// HID report. Decoupling the pin from its source key means it survives no
+// matter which key supplied the mod (KC_FF, KC_JJ, ...) or when it is released.
+void post_process_record_user(uint16_t keycode, keyrecord_t *record) {
+    if (mhn_pinned_mods) { register_mods(mhn_pinned_mods); }
+}
+#endif
 
 // Returns whether a hold-tap keycode should resolve as tap-preferred:
 //  - true  → long tapping term (HRM_TAPPING_TERM), no hold-on-other-key-press

--- a/selenium/options.h
+++ b/selenium/options.h
@@ -86,6 +86,10 @@
 
 // #define ENABLE_MOD_HOLD_NAVIGATION
 
+#if defined(ENABLE_MOD_HOLD_NAVIGATION) && !defined(VIM_NAVIGATION)
+#    error "ENABLE_MOD_HOLD_NAVIGATION requires VIM_NAVIGATION"
+#endif
+
 // Uncomment the following line to swap Space and Backspace.
 // Beware: this increases the typing load of the left thumb.
 

--- a/tests/matrix_selenium.txt
+++ b/tests/matrix_selenium.txt
@@ -68,10 +68,10 @@ ht_two_thumbs vim shift left_space        | +HT_TWO_THUMB_KEYS +VIM_NAVIGATION +
 
 # ── ENABLE_MOD_HOLD_NAVIGATION across HT modes ──────────────────────
 
-mod_hold_nav ht_none                      | +HT_NONE +ENABLE_MOD_HOLD_NAVIGATION
-mod_hold_nav ht_thumb_taps                | +HT_THUMB_TAPS +ENABLE_MOD_HOLD_NAVIGATION
-mod_hold_nav ht_hrm                       | +HT_HOME_ROW_MODS +ENABLE_MOD_HOLD_NAVIGATION
-mod_hold_nav ht_two_thumbs                | +HT_TWO_THUMB_KEYS +ENABLE_MOD_HOLD_NAVIGATION
+mod_hold_nav ht_none vim                  | +HT_NONE +VIM_NAVIGATION +ENABLE_MOD_HOLD_NAVIGATION
+mod_hold_nav ht_thumb_taps vim            | +HT_THUMB_TAPS +VIM_NAVIGATION +ENABLE_MOD_HOLD_NAVIGATION
+mod_hold_nav ht_hrm vim                    | +HT_HOME_ROW_MODS +VIM_NAVIGATION +ENABLE_MOD_HOLD_NAVIGATION
+mod_hold_nav ht_two_thumbs vim            | +HT_TWO_THUMB_KEYS +VIM_NAVIGATION +ENABLE_MOD_HOLD_NAVIGATION
 mod_hold_nav ht_hrm vim left_space        | +HT_HOME_ROW_MODS +ENABLE_MOD_HOLD_NAVIGATION +VIM_NAVIGATION +LEFT_HAND_SPACE
 
 # ── Layout variations ─────────────────────────────────────────────────

--- a/tests/test_per_option.sh
+++ b/tests/test_per_option.sh
@@ -109,16 +109,14 @@ run_selenium() {
     run_compile_test selenium "macos=on" \
         "$(enable MACOS)"
 
-    run_compile_test selenium "mod_hold_nav=on" \
-        "$(enable ENABLE_MOD_HOLD_NAVIGATION)"
-
-    run_compile_test selenium "mod_hold_nav=on left_space=on" \
-        "$(enable ENABLE_MOD_HOLD_NAVIGATION)" \
-        "$(enable LEFT_HAND_SPACE)"
-
     run_compile_test selenium "mod_hold_nav=on vim=on" \
         "$(enable ENABLE_MOD_HOLD_NAVIGATION)" \
         "$(enable VIM_NAVIGATION)"
+
+    run_compile_test selenium "mod_hold_nav=on vim=on left_space=on" \
+        "$(enable ENABLE_MOD_HOLD_NAVIGATION)" \
+        "$(enable VIM_NAVIGATION)" \
+        "$(enable LEFT_HAND_SPACE)"
 
     # Host layouts
     local host_sed=""


### PR DESCRIPTION
ENABLE_MOD_HOLD_NAVIGATION pins a modifier for the duration of a nav-layer thumb hold so VIM_PREV/VIM_NEXT can drive one-handed Alt+Tab. The old implementation registered a hardcoded LAlt on layer entry and broke twice: on Mac the VIM_PREV/VIM_NEXT morph triggers on LGUI (Cmd), not LAlt, so the morph never engaged; and an HRM releasing mid-hold cleared the modifier before the next HID report, dropping it part-way through the hold.

The pin now captures the target mod actually held when the thumb goes down (LGUI on Mac, LAlt elsewhere) and re-asserts it after every record, so it survives any source-key release for the whole hold. The option also now requires VIM_NAVIGATION at compile time instead of silently doing nothing.
