### PR TITLE
Fix ortho layouts and add planck_mit

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,9 +141,10 @@ Any QMK keyboard with a compatible physical layout works:
 - 42-key splits (3×6, 3 thumbs) — Corne (crkbd), Piantor
 - 46-key splits, inner column — Corne v4 → see [docs](docs/supported_keyboards.md#inner-column-extensions-_ex2-layouts)
 - 40-key ortho (4×10)
-- 48-key ortho (4×12) — Planck (incl. grid), Preonic-likes
+- 47-key ortho (4×12 with 2u spacebar) — Planck-likes (MIT layout)
+- 48-key ortho (4×12) — Planck-likes (grid layout)
 - 50-key ortho (5×10)
-- 60-key ortho (5×12)
+- 60-key ortho (5×12) — Preonic-likes (grid layout)
 - Iris (keebio)
 - Atreus (keyboardio) → see [docs](docs/supported_keyboards.md#atreus)
 - Lily58 (all revs) → see [docs](docs/supported_keyboards.md#lily58)

--- a/docs/supported_keyboards.md
+++ b/docs/supported_keyboards.md
@@ -13,6 +13,7 @@ The following physical layouts are supported:
 - `LAYOUT_ortho_4x12`
 - `LAYOUT_ortho_5x10`
 - `LAYOUT_ortho_5x12`
+- `LAYOUT_planck_mit`
 - `LAYOUT_planck_grid`
 - `LAYOUT_keebio_iris`
 - `LAYOUT_keyboardio_atreus` (8 keys beyond the spec — see [Atreus](#atreus))

--- a/shared/layouts.h
+++ b/shared/layouts.h
@@ -209,6 +209,21 @@
 
 //  ─────────────────< Custom keyboard-specific layouts >──────────────
 
+#elif defined ONEDEADKEY_LAYOUT_planck_mit
+#define ONEDEADKEY_LAYOUT(\
+        k11, k12, k13, k14, k15, k16,     k17, k18, k19, k1a, k1b, k1c,\
+        k21, k22, k23, k24, k25, k26,     k27, k28, k29, k2a, k2b, k2c,\
+        k31, k32, k33, k34, k35, k36,     k37, k38, k39, k3a, k3b, k3c,\
+        k41, k42, k43, k44, k45, k46,     k47, k48, k49, k4a, k4b, k4c,\
+                       k51, k52, k53,     k54, k55, k56\
+    )\
+    LAYOUT_planck_mit(\
+        k21, k22, k23, k24, k25, k26,     k27, k28, k29, k2a, k2b, k2c,\
+        k31, k32, k33, k34, k35, k36,     k37, k38, k39, k3a, k3b, k3c,\
+        k41, k42, k43, k44, k45, k46,     k47, k48, k49, k4a, k4b, k4c,\
+        XX,  XX,  XX,  k51, k52,      k55,     k56, k54, XX,  XX,  XX\
+    )
+
 #elif defined ONEDEADKEY_LAYOUT_planck_grid
 #define ONEDEADKEY_LAYOUT(\
         k11, k12, k13, k14, k15, k16,      k17, k18, k19, k1a, k1b, k1c,\

--- a/shared/layouts.h
+++ b/shared/layouts.h
@@ -157,7 +157,7 @@
              k22, k23, k24, k25, k26,     k27, k28, k29, k2a, k2b,\
              k32, k33, k34, k35, k36,     k37, k38, k39, k3a, k3b,\
              k42, k43, k44, k45, k46,     k47, k48, k49, k4a, k4b,\
-             XX,  XX,  k51, k52, k53,     k54, k55, k56, XX,  XX,\
+             XX,  XX,  k51, k52, k53,     k54, k55, k56, XX,  XX\
     )
 
 #elif defined ONEDEADKEY_LAYOUT_ortho_4x12
@@ -172,7 +172,7 @@
         k21, k22, k23, k24, k25, k26,     k27, k28, k29, k2a, k2b, k2c,\
         k31, k32, k33, k34, k35, k36,     k37, k38, k39, k3a, k3b, k3c,\
         k41, k42, k43, k44, k45, k46,     k47, k48, k49, k4a, k4b, k4c,\
-        XX,  XX,  XX,  k51, k52, k53,     k54, k55, k56, XX,  XX,  XX,\
+        XX,  XX,  XX,  k51, k52, k53,     k54, k55, k56, XX,  XX,  XX\
     )
 
 #elif defined ONEDEADKEY_LAYOUT_ortho_5x10
@@ -188,7 +188,7 @@
              k22, k23, k24, k25, k26,     k27, k28, k29, k2a, k2b,\
              k32, k33, k34, k35, k36,     k37, k38, k39, k3a, k3b,\
              k42, k43, k44, k45, k46,     k47, k48, k49, k4a, k4b,\
-             XX,  XX,  k51, k52, k53,     k54, k55, k56, XX,  XX,\
+             XX,  XX,  k51, k52, k53,     k54, k55, k56, XX,  XX\
     )
 
 #elif defined ONEDEADKEY_LAYOUT_ortho_5x12
@@ -204,7 +204,7 @@
         k21, k22, k23, k24, k25, k26,     k27, k28, k29, k2a, k2b, k2c,\
         k31, k32, k33, k34, k35, k36,     k37, k38, k39, k3a, k3b, k3c,\
         k41, k42, k43, k44, k45, k46,     k47, k48, k49, k4a, k4b, k4c,\
-        XX,  XX,  XX,  k51, k52, k53,     k54, k55, k56, XX,  XX,  XX,\
+        XX,  XX,  XX,  k51, k52, k53,     k54, k55, k56, XX,  XX,  XX\
     )
 
 //  ─────────────────< Custom keyboard-specific layouts >──────────────
@@ -216,12 +216,13 @@
         k31, k32, k33, k34, k35, k36,      k37, k38, k39, k3a, k3b, k3c,\
         k41, k42, k43, k44, k45, k46,      k47, k48, k49, k4a, k4b, k4c,\
                        k51, k52, k53,      k54, k55, k56\
+    )\
     LAYOUT_planck_grid(\
         k11, k12, k13, k14, k15, k16,     k17, k18, k19, k1a, k1b, k1c,\
         k21, k22, k23, k24, k25, k26,     k27, k28, k29, k2a, k2b, k2c,\
         k31, k32, k33, k34, k35, k36,     k37, k38, k39, k3a, k3b, k3c,\
         k41, k42, k43, k44, k45, k46,     k47, k48, k49, k4a, k4b, k4c,\
-        XX,  XX,  XX,  k53, k51,      k55,     k56, k54, XX,  XX,  XX,\
+        XX,  XX,  XX,  k53, k51,      k55,     k56, k54, XX,  XX,  XX\
     )
 
 #elif defined ONEDEADKEY_LAYOUT_keebio_iris

--- a/shared/layouts.h
+++ b/shared/layouts.h
@@ -218,11 +218,10 @@
                        k51, k52, k53,      k54, k55, k56\
     )\
     LAYOUT_planck_grid(\
-        k11, k12, k13, k14, k15, k16,     k17, k18, k19, k1a, k1b, k1c,\
         k21, k22, k23, k24, k25, k26,     k27, k28, k29, k2a, k2b, k2c,\
         k31, k32, k33, k34, k35, k36,     k37, k38, k39, k3a, k3b, k3c,\
         k41, k42, k43, k44, k45, k46,     k47, k48, k49, k4a, k4b, k4c,\
-        XX,  XX,  XX,  k53, k51,      k55,     k56, k54, XX,  XX,  XX\
+	XX,  XX,  XX,  k51, k52, k53,     k54, k55, k56, XX,  XX,  XX\
     )
 
 #elif defined ONEDEADKEY_LAYOUT_keebio_iris


### PR DESCRIPTION
This PR is targeted at orthogonal layouts.

Il removes extra trailing commas in ortho layouts, and a missing closing parenthese in planck_grid, that would make qmk compile fail.

It also updates `planck_grid` which I believe incorrectly had an extra top row and a 2u space key.

Il finally adds the actual 2u space key Planck layout, `planck_mit`.

Tested to work with KPrepublic’s CSTC40 rev3, which has a planck_mit layout.